### PR TITLE
範囲選択画面のユーザビリティ向上

### DIFF
--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentGizmo.cpp
@@ -18,14 +18,13 @@ FPLATEAUExtentGizmo::FPLATEAUExtentGizmo()
 void FPLATEAUExtentGizmo::DrawHandle(int Index, FColor Color, const FSceneView* View, FPrimitiveDrawInterface* PDI, double CameraDistance) {
     SphereMaterial.Get()->SetVectorParameterValue(FName("Color"), Color);
 
-    double zoomRate = 1.0 / (CameraDistance / 10000);
-    double radius = FMath::Min(CameraDistance / 20, 500);
+    const auto Radius = FMath::Min(CameraDistance / 20, 500);
 
     DrawSphere(
         PDI,
         GetHandlePosition(Index),
         FRotator(),
-        FVector(radius),
+        FVector(Radius),
         24, 6, SphereMaterial->GetRenderProxy(), 9
     );
 
@@ -33,7 +32,7 @@ void FPLATEAUExtentGizmo::DrawHandle(int Index, FColor Color, const FSceneView* 
         PDI,
         GetHandlePosition(Index),
         FRotator(),
-        FVector(radius),
+        FVector(Radius),
         24, 6, SphereMaterial->GetRenderProxy(), 9
     );
 }


### PR DESCRIPTION
## 関連リンク

## 実装内容
PLATEAUExtentGizmo.cppファイルのDrawHandle関数内で、
radius変数の設定方法を変更しました。

距離が10000以下　：　変更前のradiusと同じ
距離が10000以上　：　radiusのサイズ固定

## マージ前確認項目

## 動作確認
ミーティングで画面共有した際の動作と同じです。

## その他

