### PR TITLE
サーバー接続時にクラッシュする問題を修正

### DIFF
--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUServerDatasetSelectPanel.h
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUServerDatasetSelectPanel.h
@@ -41,7 +41,6 @@ public:
         OnSelectDataset = Function;
     }
 
-    //virtual void Tick(FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
     virtual void Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
 
 private:


### PR DESCRIPTION
## 実装内容
PLATEAU SDK画面を開いた際、サーバー接続の処理でクラッシュしてしまう問題を解消した。
SPLATEAUServerDatasetSelectPanel内でスレッドの実行中にSPLATEAUServerDatasetSelectPanelのインスタンスが破棄されてしまう際、メンバーにアクセスできなくなってしまうことが原因だったため、スレッド内でインスタンスのスマートポインタを保持するように変更した。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
