### PR TITLE
プロジェクトのパスに "plateau" が含まれているとインポート時のテクスチャパスが正しく記録されないバグを修正

### DIFF
--- a/PLATEAU-SDK-for-Unreal.uplugin
+++ b/PLATEAU-SDK-for-Unreal.uplugin
@@ -5,7 +5,7 @@
 	"FriendlyName": "PLATEAU SDK for Unreal",
 	"Description": "",
 	"Category": "Geospatial",
-	"CreatedBy": "Ministry of Land、Infrastructure and Transport",
+	"CreatedBy": "Ministry of Land, Infrastructure and Transport",
 	"CreatedByURL": "https://github.com/Synesthesias/Plateau-SDK-for-Unreal.git",
 	"DocsURL": "",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/0a6b04bd9ae64d6dadd81c42a391c8f1",

--- a/Source/PLATEAUEditor/PLATEAUEditor.Build.cs
+++ b/Source/PLATEAUEditor/PLATEAUEditor.Build.cs
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 using UnrealBuildTool;
 using System;

--- a/Source/PLATEAUEditor/Private/CityModelLoaderDetails/PLATEAUCityModelLoaderDetails.cpp
+++ b/Source/PLATEAUEditor/Private/CityModelLoaderDetails/PLATEAUCityModelLoaderDetails.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUCityModelLoaderDetails.h"
 

--- a/Source/PLATEAUEditor/Private/CityModelLoaderDetails/PLATEAUCityModelLoaderDetails.h
+++ b/Source/PLATEAUEditor/Private/CityModelLoaderDetails/PLATEAUCityModelLoaderDetails.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "ExtentEditor/PLATEAUExtentEditor.h"
 #include "ExtentEditor/SPLATEAUExtentEditorViewport.h"

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUExtentEditorVPClient.h"
 #include "PLATEAUExtentEditor.h"

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentGizmo.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUExtentGizmo.h"

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentGizmo.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUFeatureInfoDisplay.h"
 #include "PLATEAUGeometry.h"

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUMeshCodeGizmo.h"

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "ExtentEditor/SPLATEAUExtentEditorViewport.h"
 #include "ExtentEditor/PLATEAUExtentEditorVPClient.h"

--- a/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/PLATEAUBasemap.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUBasemap.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUBasemap.h"

--- a/Source/PLATEAUEditor/Private/PLATEAUBasemap.h
+++ b/Source/PLATEAUEditor/Private/PLATEAUBasemap.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/PLATEAUEditor.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUEditor.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUEditor.h"
 #include "PLATEAUCityModelLoader.h"

--- a/Source/PLATEAUEditor/Private/PLATEAUEditorStyle.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUEditorStyle.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUEditorStyle.h"
 

--- a/Source/PLATEAUEditor/Private/PLATEAUEditorStyle.h
+++ b/Source/PLATEAUEditor/Private/PLATEAUEditorStyle.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/PLATEAUFeatureExportSettingsDetails.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUFeatureExportSettingsDetails.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUFeatureExportSettingsDetails.h"
 

--- a/Source/PLATEAUEditor/Private/PLATEAUFeatureExportSettingsDetails.h
+++ b/Source/PLATEAUEditor/Private/PLATEAUFeatureExportSettingsDetails.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/PLATEAUFeatureImportSettingsDetails.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUFeatureImportSettingsDetails.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUFeatureImportSettingsDetails.h"
 

--- a/Source/PLATEAUEditor/Private/PLATEAUFeatureImportSettingsDetails.h
+++ b/Source/PLATEAUEditor/Private/PLATEAUFeatureImportSettingsDetails.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/PLATEAUInstancedCityModelDetails.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUInstancedCityModelDetails.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUInstancedCityModelDetails.h"

--- a/Source/PLATEAUEditor/Private/PLATEAUInstancedCityModelDetails.h
+++ b/Source/PLATEAUEditor/Private/PLATEAUInstancedCityModelDetails.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/PLATEAUWindow.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUWindow.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUWindow.h"
 

--- a/Source/PLATEAUEditor/Private/SPLATEAUExportPanel.cpp
+++ b/Source/PLATEAUEditor/Private/SPLATEAUExportPanel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "SPLATEAUExportPanel.h"
 

--- a/Source/PLATEAUEditor/Private/SPLATEAUExportPanel.h
+++ b/Source/PLATEAUEditor/Private/SPLATEAUExportPanel.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/SPLATEAUImportPanel.cpp
+++ b/Source/PLATEAUEditor/Private/SPLATEAUImportPanel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "SPLATEAUImportPanel.h"
 

--- a/Source/PLATEAUEditor/Private/SPLATEAUImportPanel.h
+++ b/Source/PLATEAUEditor/Private/SPLATEAUImportPanel.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/SPLATEAUMainTab.cpp
+++ b/Source/PLATEAUEditor/Private/SPLATEAUMainTab.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "SPLATEAUMainTab.h"

--- a/Source/PLATEAUEditor/Private/SPLATEAUMainTab.h
+++ b/Source/PLATEAUEditor/Private/SPLATEAUMainTab.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/Widgets/PLATEAUServerConnectionSettingsDetails.cpp
+++ b/Source/PLATEAUEditor/Private/Widgets/PLATEAUServerConnectionSettingsDetails.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUServerConnectionSettingsDetails.h"
 

--- a/Source/PLATEAUEditor/Private/Widgets/PLATEAUServerConnectionSettingsDetails.h
+++ b/Source/PLATEAUEditor/Private/Widgets/PLATEAUServerConnectionSettingsDetails.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUExtentEditButton.cpp
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUExtentEditButton.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "SPLATEAUExtentEditButton.h"
 

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUExtentEditButton.h
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUExtentEditButton.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFeatureImportSettingsView.cpp
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFeatureImportSettingsView.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "SPLATEAUFeatureImportSettingsView.h"
 

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFeatureImportSettingsView.h
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFeatureImportSettingsView.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 #pragma once

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFilteringPanel.cpp
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFilteringPanel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "SPLATEAUFilteringPanel.h"
 #include "SlateOptMacros.h"

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFilteringPanel.h
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUFilteringPanel.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUServerDatasetSelectPanel.cpp
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUServerDatasetSelectPanel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "SPLATEAUServerDatasetSelectPanel.h"
 

--- a/Source/PLATEAUEditor/Private/Widgets/SPLATEAUServerDatasetSelectPanel.h
+++ b/Source/PLATEAUEditor/Private/Widgets/SPLATEAUServerDatasetSelectPanel.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Public/PLATEAUEditor.h
+++ b/Source/PLATEAUEditor/Public/PLATEAUEditor.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAUEditor/Public/PLATEAUWindow.h
+++ b/Source/PLATEAUEditor/Public/PLATEAUWindow.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Private/CityGML/PLATEAUAttributeValue.cpp
+++ b/Source/PLATEAURuntime/Private/CityGML/PLATEAUAttributeValue.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "CityGML/PLATEAUAttributeValue.h"

--- a/Source/PLATEAURuntime/Private/CityGML/PLATEAUCityGmlProxy.cpp
+++ b/Source/PLATEAURuntime/Private/CityGML/PLATEAUCityGmlProxy.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "CityGML/PLATEAUCityGmlProxy.h"
 #include "CityGML/PLATEAUCityModel.h"

--- a/Source/PLATEAURuntime/Private/CityGML/PLATEAUCityModel.cpp
+++ b/Source/PLATEAURuntime/Private/CityGML/PLATEAUCityModel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "CityGML/PLATEAUCityModel.h"

--- a/Source/PLATEAURuntime/Private/CityGML/PLATEAUCityObject.cpp
+++ b/Source/PLATEAURuntime/Private/CityGML/PLATEAUCityObject.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "CityGML/PLATEAUCityObject.h"
 #include "CityGML/PLATEAUAttributeValue.h"

--- a/Source/PLATEAURuntime/Private/PLATEAUCityModelLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUCityModelLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUCityModelLoader.h"

--- a/Source/PLATEAURuntime/Private/PLATEAUGeometry.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUGeometry.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUGeometry.h"

--- a/Source/PLATEAURuntime/Private/PLATEAUInstancedCityModel.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUInstancedCityModel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
 #include "PLATEAUInstancedCityModel.h"

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUMeshExporter.h"
 #include "plateau/mesh_writer/gltf_writer.h"
@@ -94,12 +94,13 @@ TArray<std::shared_ptr<plateau::polygonMesh::Model>> FPLATEAUMeshExporter::Creat
     TArray<std::shared_ptr<plateau::polygonMesh::Model>> ModelArray;
     const auto RootComponent = ModelActor->GetRootComponent();
     const auto Components = RootComponent->GetAttachChildren();
-    for (int i = 0; i < Components.Num(); i++) {
+    for (int i = 0; i < Components.Num(); i++)
+    {
         //BillboardComponentなるコンポーネントがついていることがあるので無視
-        if (!Components[i]->GetName().Contains("BillboardComponent")) {
-            ModelArray.Add(CreateModel(Components[i], Option));
-            ModelNames.Add(RemoveSuffix(Components[i]->GetName()));
-        }
+        if (Components[i]->GetName().Contains("BillboardComponent")) continue;
+        
+        ModelArray.Add(CreateModel(Components[i], Option));
+        ModelNames.Add(RemoveSuffix(Components[i]->GetName()));
     }
     return ModelArray;
 }
@@ -174,7 +175,7 @@ void FPLATEAUMeshExporter::CreateMesh(plateau::polygonMesh::Mesh& OutMesh, UScen
         const int EndIndex = Section.FirstIndex + Section.NumTriangles * 3;
 
         //マテリアルがテクスチャを持っているようなら取得、設定によってはスキップ
-        FString PathName;
+        FString PathName = FString("");
         if (Option.bExportTexture) {
             const auto  MaterialInstance = (UMaterialInstance*)StaticMeshComponent->GetMaterial(k);
             if (MaterialInstance->TextureParameterValues.Num() > 0) {
@@ -186,7 +187,10 @@ void FPLATEAUMeshExporter::CreateMesh(plateau::polygonMesh::Mesh& OutMesh, UScen
             }
         }
 
-        OutMesh.addSubMesh(TCHAR_TO_UTF8(*PathName), FirstIndex, EndIndex);
+        if (!PathName.IsEmpty())
+        {
+            OutMesh.addSubMesh(TCHAR_TO_UTF8(*PathName), FirstIndex, EndIndex);
+        }
     }
 
     // TODO: MeshDescription使用する方法だと何故かUV取得できない

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUMeshLoader.h"
 #include "PLATEAUTextureLoader.h"

--- a/Source/PLATEAURuntime/Private/PLATEAURuntime.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAURuntime.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAURuntime.h"
 

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "PLATEAUTextureLoader.h"
 
@@ -150,10 +150,11 @@ namespace {
     }
 }
 
-UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath) {
+UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSlash) {
     int32 Width, Height;
     EPixelFormat PixelFormat;
     TArray64<uint8> UncompressedData;
+    const auto TexturePath = TexturePath_SlashOrBackSlash.Replace(*FString("\\"), *FString("/"));
     if (!TryLoadAndUncompressImageFile(TexturePath, UncompressedData, Width, Height, PixelFormat))
         return nullptr;
 
@@ -179,9 +180,9 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath) {
                 NewTexture = NewObject<UTexture2D>(Package, NAME_None, RF_Public | RF_Standalone | RF_MarkAsRootSet);
 
                 // テクスチャ名が正しくキャッシュフォルダからの相対パスになるよう変更
-                FString TextureRelativePath;
                 FString TextureRelativePathPrefix;
-                TexturePath.Split(TEXT("PLATEAU\\"), &TextureRelativePathPrefix, &TextureRelativePath);
+                const auto BaseDir = FPaths::ProjectContentDir() + "PLATEAU/";
+                auto TextureRelativePath = TexturePath.Replace(*BaseDir, *FString(""));
                 DesiredTextureName = TextureRelativePath;
                 FString NewUniqueName = DesiredTextureName;
                 if (!NewTexture->Rename(*NewUniqueName, nullptr, REN_Test)) {

--- a/Source/PLATEAURuntime/Public/CityGML/PLATEAUCityGmlProxy.h
+++ b/Source/PLATEAURuntime/Public/CityGML/PLATEAUCityGmlProxy.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/CityGML/PLATEAUCityModel.h
+++ b/Source/PLATEAURuntime/Public/CityGML/PLATEAUCityModel.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/CityGML/PLATEAUCityObject.h
+++ b/Source/PLATEAURuntime/Public/CityGML/PLATEAUCityObject.h
@@ -1,4 +1,4 @@
-// Copyright © 2023 Ministry of Land、Infrastructure and Transport
+// Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUCityModelLoader.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUCityModelLoader.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of Land、Infrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUExportSettings.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUExportSettings.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of Land、Infrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUGeometry.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUGeometry.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of Land、Infrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUImportSettings.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUImportSettings.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of Land、Infrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUInstancedCityModel.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUInstancedCityModel.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of Land、Infrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUMeshExporter.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUMeshExporter.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of LandÅAInfrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 

--- a/Source/PLATEAURuntime/Public/PLATEAUMeshLoader.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUMeshLoader.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Ministry of Land、Infrastructure and Transport
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
 
 #pragma once
 


### PR DESCRIPTION


## 実装内容
- プロジェクトのパスに "plateau" が含まれているとインポート時のテクスチャパスが正しく記録されないバグを修正しました
- 上記を原因としてエクスポート時にクラッシュする問題も一緒に解決されました

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

