### PR TITLE
Unrealでの範囲選択画面に地域メッシュ番号を表示

### DIFF
--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
@@ -222,10 +222,10 @@ void FPLATEAUExtentEditorViewportClient::DrawCanvas(FViewport& InViewport, FScen
 
     const double CameraDistance = GetViewTransform().GetLocation().Z;
     const auto& MeshCodes = DatasetAccessor->getMeshCodes();
-    auto meshptr = MeshCodes.begin();
+    auto Meshptr = MeshCodes.begin();
 
     for (const auto& Gizmo : MeshCodeGizmos) {
-        const auto code = (*meshptr++).get();
+        const auto code = (*Meshptr++).get();
         Gizmo.DrawRegionMeshID(InViewport, View, Canvas, code.c_str(), CameraDistance);
     }
 }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
@@ -218,6 +218,18 @@ void FPLATEAUExtentEditorViewportClient::Draw(const FSceneView* View, FPrimitive
     }
 }
 
+void FPLATEAUExtentEditorViewportClient::DrawCanvas(FViewport& InViewport, FSceneView& View, FCanvas& Canvas) {
+
+    const double CameraDistance = GetViewTransform().GetLocation().Z;
+    const auto& MeshCodes = DatasetAccessor->getMeshCodes();
+    auto meshptr = MeshCodes.begin();
+
+    for (const auto& Gizmo : MeshCodeGizmos) {
+        const auto code = (*meshptr++).get();
+        Gizmo.DrawRegionMeshID(InViewport, View, Canvas, code.c_str(), CameraDistance);
+    }
+}
+
 void FPLATEAUExtentEditorViewportClient::TrackingStarted(const FInputEventState& InInputState, bool bIsDragging,
     bool bNudge) {
     if (!TryGetWorldPositionOfCursor(TrackingStartedPosition))

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
@@ -224,6 +224,8 @@ void FPLATEAUExtentEditorViewportClient::DrawCanvas(FViewport& InViewport, FScen
     const auto& MeshCodes = DatasetAccessor->getMeshCodes();
     auto Meshptr = MeshCodes.begin();
 
+    check(MeshCodes.size() == MeshCodeGizmos.Num());
+
     for (const auto& Gizmo : MeshCodeGizmos) {
         const auto code = (*Meshptr++).get();
         Gizmo.DrawRegionMeshID(InViewport, View, Canvas, code.c_str(), CameraDistance);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -29,6 +29,7 @@ public:
     // FEditorViewportClient interface
     virtual void Tick(float DeltaSeconds) override;
     virtual void Draw(const FSceneView* View, FPrimitiveDrawInterface* PDI) override;
+    virtual void DrawCanvas(FViewport& InViewport, FSceneView& View, FCanvas& Canvas) override;
     virtual void TrackingStarted(const struct FInputEventState& InInputState, bool bIsDragging, bool bNudge) override;
     virtual void TrackingStopped() override;
     virtual bool ShouldScaleCameraSpeedByDistance() const override;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
@@ -51,9 +51,9 @@ void FPLATEAUMeshCodeGizmo::DrawExtent(const FSceneView* View, FPrimitiveDrawInt
     }
 }
 
-void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(FViewport& InViewport, FSceneView& View, FCanvas& Canvas, FString MeshCode, double CameraDistance) const {
-    const auto NearOffset = 4000;
-    const auto FarOffset = 100000;
+void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& MeshCode, double CameraDistance) const {
+    constexpr auto NearOffset = 8000;
+    constexpr auto FarOffset = 100000;
 
     const auto CenterX = MinX + (MaxX - MinX) / 2;
     const auto CenterY = MinY + (MaxY - MinY) / 2 * 1.28;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
@@ -8,6 +8,8 @@
 #include <plateau/dataset/mesh_code.h>
 #include <plateau/geometry/geo_reference.h>
 
+#include "Engine.h"
+
 FPLATEAUMeshCodeGizmo::FPLATEAUMeshCodeGizmo()
     : MinX(-500), MinY(-500), MaxX(500), MaxY(500), IsSelected(false), LineThickness(1.0f) {}
 
@@ -46,6 +48,40 @@ void FPLATEAUMeshCodeGizmo::DrawExtent(const FSceneView* View, FPrimitiveDrawInt
         Q.Y = P.Y;
         P.X = Box.Min.X; Q.X = Box.Max.X;
         PDI->DrawLine(P, Q, Color, DepthPriority, 1, 0, true);
+    }
+}
+
+void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(FViewport& InViewport, FSceneView& View, FCanvas& Canvas, FString MeshCode, double CameraDistance) const {
+    const auto NearOffset = 4000;
+    const auto FarOffset = 100000;
+
+    const auto CenterX = MinX + (MaxX - MinX) / 2;
+    const auto CenterY = MinY + (MaxY - MinY) / 2 * 1.28;
+
+    const auto ViewPlane = View.Project(FVector(CenterX, CenterY, 0));
+
+    const auto HalfX = InViewport.GetSizeXY().X / 2;
+    const auto HalfY = InViewport.GetSizeXY().Y / 2;
+
+    const auto XPos = HalfX + (HalfX * ViewPlane.X);
+    const auto YPos = HalfY + (HalfY * -ViewPlane.Y);
+
+    const UFont* ViewFont = GEngine->GetLargeFont();
+
+    const auto HalfWidth = ViewFont->GetStringSize(*MeshCode) / 2;
+    const auto HalfHeight = ViewFont->GetStringHeightSize(*MeshCode) / 2;
+
+    const auto Color = MeshCodeLevel == 2
+        ? FColor(10, 10, 10)
+        : FColor::Blue;
+
+    if (ViewPlane.W > 0.f) {
+        if ((MeshCodeLevel == 2) && (CameraDistance > NearOffset) && (CameraDistance < FarOffset)) {
+            Canvas.DrawShadowedText(XPos - HalfWidth, YPos - HalfHeight, FText::FromString(MeshCode), ViewFont, Color);
+        }
+        else if ((MeshCodeLevel != 2) && (CameraDistance <= NearOffset)) {
+            Canvas.DrawShadowedText(XPos - HalfWidth, YPos - HalfHeight, FText::FromString(MeshCode), ViewFont, Color);
+        }
     }
 }
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
@@ -58,10 +58,11 @@ void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(FViewport& InViewport, FSceneView& 
     const auto CenterX = MinX + (MaxX - MinX) / 2;
     const auto CenterY = MinY + (MaxY - MinY) / 2 * 1.28;
 
+    const auto dpi = Canvas.GetDPIScale();
     const auto ViewPlane = View.Project(FVector(CenterX, CenterY, 0));
 
-    const auto HalfX = InViewport.GetSizeXY().X / 2;
-    const auto HalfY = InViewport.GetSizeXY().Y / 2;
+    const auto HalfX = InViewport.GetSizeXY().X / 2 / dpi;
+    const auto HalfY = InViewport.GetSizeXY().Y / 2 / dpi;
 
     const auto XPos = HalfX + (HalfX * ViewPlane.X);
     const auto YPos = HalfY + (HalfY * -ViewPlane.Y);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
@@ -21,7 +21,7 @@ public:
     FPLATEAUMeshCodeGizmo();
 
     void DrawExtent(const FSceneView* View, FPrimitiveDrawInterface* PDI) const;
-    void DrawRegionMeshID(FViewport& InViewport, FSceneView& View, FCanvas& Canvas, FString MeshCode, double CameraDistance) const;
+    void DrawRegionMeshID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& MeshCode, double CameraDistance) const;
 
     /**
      * @brief 内部状態から範囲の最小値を取得します。

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
@@ -21,6 +21,7 @@ public:
     FPLATEAUMeshCodeGizmo();
 
     void DrawExtent(const FSceneView* View, FPrimitiveDrawInterface* PDI) const;
+    void DrawRegionMeshID(FViewport& InViewport, FSceneView& View, FCanvas& Canvas, FString MeshCode, double CameraDistance) const;
 
     /**
      * @brief 内部状態から範囲の最小値を取得します。


### PR DESCRIPTION

## 実装内容

■ PLATEAUExtentEditorVPClient.cppの変更内容

　地域メッシュ番号をキャンバスに描画する必要があるため
　「FCanvas」が利用可能なDrawCanvas関数を追加しました。

　DrawCanvas関数内から、実際に地域メッシュ番号を描画する、
　DrawRegionMeshID関数を呼び出す構成になっています。

■ PLATEAUMeshCodeGizmo.cppの変更内容

　FPLATEAUMeshCodeGizmoクラス内で、実際に地域メッシュ番号を
　描画するために、DrawRegionMeshID関数を追加しました。

描画するメッシュ番号の文字列のサイズが固定になる仕様を回避するために、
カメラの距離に応じて、２次メッシュ、３次メッシュの表示を切り替えます。

## 動作確認

範囲選択ウインドウ内で、カメラが一定の距離よりも近い場合に、３次メッシュ（ブルー）の
地域メッシュが表示されます。カメラの距離が遠くなると2次メッシュ（ブラック）の
地域メッシュ番号が表示されます。カメラの距離が一定以上遠くなると、表示領域が
確保できないため、地域メッシュ番号を非表示にします。

> 4000以下　：　３次メッシュの地域メッシュ番号（ブルー）を表示します。
> 4000 - 100000　：　２次メッシュの地域メッシュ番号（ブラック）を表示します。
>            100000以上　：　表示領域が確保できないため、地域メッシュ番号を非表示にします。