### PR TITLE
バグ修正: Macでのインポートバグ、Mac&Winでエクスポートするモデルの乱れ

### DIFF
--- a/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
@@ -170,9 +170,12 @@ void FPLATEAUMeshExporter::CreateMesh(plateau::polygonMesh::Mesh& OutMesh, UScen
 
     for (int k = 0; k < RenderMesh.Sections.Num(); k++) {
         const auto& Section = RenderMesh.Sections[k];
+        if(Section.NumTriangles <= 0) continue;
+        
         //サブメッシュの開始・終了インデックス計算
         const int FirstIndex = Section.FirstIndex;
-        const int EndIndex = Section.FirstIndex + Section.NumTriangles * 3;
+        const int EndIndex = Section.FirstIndex + Section.NumTriangles * 3 - 1;
+        ensureAlwaysMsgf((EndIndex - FirstIndex + 1) % 3 == 0, TEXT("SubMesh indices size should be multiple of 3.") );
 
         //マテリアルがテクスチャを持っているようなら取得、設定によってはスキップ
         FString PathName = FString("");

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
@@ -52,7 +52,7 @@ void FPLATEAUMeshExporter::ExportAsOBJ(const FString ExportPath, APLATEAUInstanc
     for (int i = 0; i < ModelDataArray.Num(); i++) {
         if (ModelDataArray[i]->getRootNodeCount() != 0) {
             const FString ExportPathWithName = ExportPath + "/" + ModelNames[i] + ".obj";
-            Writer.write(TCHAR_TO_UTF8(*ExportPathWithName.Replace(TEXT("/"), TEXT("\\"))), *ModelDataArray[i]);
+            Writer.write(TCHAR_TO_UTF8(*ExportPathWithName), *ModelDataArray[i]);
         }
     }
 }
@@ -70,7 +70,7 @@ void FPLATEAUMeshExporter::ExportAsFBX(const FString ExportPath, APLATEAUInstanc
     for (int i = 0; i < ModelDataArray.Num(); i++) {
         if (ModelDataArray[i]->getRootNodeCount() != 0) {
             const FString ExportPathWithName = ExportPath + "/" + ModelNames[i] + ".fbx";
-            Writer.write(TCHAR_TO_UTF8(*ExportPathWithName.Replace(TEXT("/"), TEXT("\\"))), *ModelDataArray[i], Option.FbxWriteOptions);
+            Writer.write(TCHAR_TO_UTF8(*ExportPathWithName), *ModelDataArray[i], Option.FbxWriteOptions);
         }
     }
 }
@@ -85,7 +85,7 @@ void FPLATEAUMeshExporter::ExportAsGLTF(const FString ExportPath, APLATEAUInstan
             const FString ExportPathWithFolder = ExportPath + "/" + ModelNames[i];
 
             std::filesystem::create_directory(TCHAR_TO_UTF8(*ExportPathWithFolder.Replace(TEXT("/"), TEXT("\\"))));
-            Writer.write(TCHAR_TO_UTF8(*ExportPathWithName.Replace(TEXT("/"), TEXT("\\"))), *ModelDataArray[i], Option.GltfWriteOptions);
+            Writer.write(TCHAR_TO_UTF8(*ExportPathWithName), *ModelDataArray[i], Option.GltfWriteOptions);
         }
     }
 }
@@ -185,7 +185,8 @@ void FPLATEAUMeshExporter::CreateMesh(plateau::polygonMesh::Mesh& OutMesh, UScen
                 FMaterialParameterMetadata MetaData;
                 MaterialInstance->TextureParameterValues[0].GetValue(MetaData);
                 if (const auto Texture = MetaData.Value.Texture; Texture != nullptr) {
-                    PathName = (FPaths::ProjectContentDir() + "PLATEAU/" + Texture->GetName()).Replace(TEXT("/"), TEXT("\\"));
+                    const auto BaseDir = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*(FPaths::ProjectContentDir() + "PLATEAU/"));
+                    PathName = BaseDir + Texture->GetName();
                 }
             }
         }

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
@@ -243,6 +243,8 @@ void FPLATEAUMeshExporter::CreateMesh(plateau::polygonMesh::Mesh& OutMesh, UScen
     OutMesh.addUV1(UV1, Vertices.size());
     OutMesh.addUV2WithSameVal(TVec2f(0.0f, 0.0f), Vertices.size());
     OutMesh.addUV3WithSameVal(TVec2f(0.0f, 0.0f), Vertices.size());
+    ensureAlwaysMsgf(OutMesh.getIndices().size() % 3 == 0, TEXT("Indice size should be multiple of 3."));
+    ensureAlwaysMsgf(OutMesh.getVertices().size() == OutMesh.getUV1().size(), TEXT("Size of vertices and uv1 should be same."));
 }
 
 FString FPLATEAUMeshExporter::RemoveSuffix(const FString ComponentName) {

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
@@ -163,9 +163,9 @@ void FPLATEAUMeshExporter::CreateMesh(plateau::polygonMesh::Mesh& OutMesh, UScen
     }
 
     for (int32 TriangleIndex = 0; TriangleIndex < RenderMesh.IndexBuffer.GetNumIndices() / 3; ++TriangleIndex) {
-        OutIndices.push_back(RenderMesh.IndexBuffer.GetIndex(TriangleIndex * 3 + 2));
-        OutIndices.push_back(RenderMesh.IndexBuffer.GetIndex(TriangleIndex * 3 + 1));
         OutIndices.push_back(RenderMesh.IndexBuffer.GetIndex(TriangleIndex * 3));
+        OutIndices.push_back(RenderMesh.IndexBuffer.GetIndex(TriangleIndex * 3 + 1));
+        OutIndices.push_back(RenderMesh.IndexBuffer.GetIndex(TriangleIndex * 3 + 2));
     }
 
     for (int k = 0; k < RenderMesh.Sections.Num(); k++) {

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -156,11 +156,12 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
     int32 Width, Height;
     EPixelFormat PixelFormat;
     TArray64<uint8> UncompressedData;
+    if(TexturePath_SlashOrBackSlash.IsEmpty()) return nullptr;
     // 引数のパスのセパレーターはOSによって "/" か "¥" なので "/" に統一します。
     const auto TexturePath_NotNormalized = TexturePath_SlashOrBackSlash.Replace(*FString("\\"), *FString("/"));
     // パスに ".." が含まれる場合は、std::filesystem の機能を使って適用します。
     fs::path TexturePathCpp = fs::u8path(TCHAR_TO_UTF8(*TexturePath_NotNormalized)).lexically_normal();
-    const auto TexturePath = FString(UTF8_TO_TCHAR(TexturePathCpp.c_str()));
+    const FString TexturePath = TexturePathCpp.c_str();
 
     if (!TryLoadAndUncompressImageFile(TexturePath, UncompressedData, Width, Height, PixelFormat))
         return nullptr;

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -7,6 +7,8 @@
 #include "RHICommandList.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "UObject/SavePackage.h"
+#include <filesystem>
+namespace fs = std::filesystem;
 
 #if WITH_EDITOR
 
@@ -154,7 +156,12 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
     int32 Width, Height;
     EPixelFormat PixelFormat;
     TArray64<uint8> UncompressedData;
-    const auto TexturePath = TexturePath_SlashOrBackSlash.Replace(*FString("\\"), *FString("/"));
+    // 引数のパスのセパレーターはOSによって "/" か "¥" なので "/" に統一します。
+    const auto TexturePath_NotNormalized = TexturePath_SlashOrBackSlash.Replace(*FString("\\"), *FString("/"));
+    // パスに ".." が含まれる場合は、std::filesystem の機能を使って適用します。
+    fs::path TexturePathCpp = fs::u8path(TCHAR_TO_UTF8(*TexturePath_NotNormalized)).lexically_normal();
+    const auto TexturePath = FString(UTF8_TO_TCHAR(TexturePathCpp.c_str()));
+
     if (!TryLoadAndUncompressImageFile(TexturePath, UncompressedData, Width, Height, PixelFormat))
         return nullptr;
 
@@ -181,7 +188,7 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
 
                 // テクスチャ名が正しくキャッシュフォルダからの相対パスになるよう変更
                 FString TextureRelativePathPrefix;
-                const auto BaseDir = FPaths::ProjectContentDir() + "PLATEAU/";
+                const auto BaseDir = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*(FPaths::ProjectContentDir() + "PLATEAU/"));
                 auto TextureRelativePath = TexturePath.Replace(*BaseDir, *FString(""));
                 DesiredTextureName = TextureRelativePath;
                 FString NewUniqueName = DesiredTextureName;


### PR DESCRIPTION


## 実装内容
- Win&Macで SubMeshのインデックス計算が誤っていたのを修正しました。
- Win&Macでエクスポート時にすべての面の法線が裏返る問題を修正しました。
- Macでインポート時に記録されるテクスチャパスが違うのを修正しました。
