### PR TITLE
プルリク#83の修正 : Macテクスチャ保存のバグ修正

### DIFF
--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -157,11 +157,12 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
     EPixelFormat PixelFormat;
     TArray64<uint8> UncompressedData;
     if(TexturePath_SlashOrBackSlash.IsEmpty()) return nullptr;
-    // 引数のパスのセパレーターはOSによって "/" か "¥" なので "/" に統一します。
-    const auto TexturePath_NotNormalized = TexturePath_SlashOrBackSlash.Replace(*FString("\\"), *FString("/"));
+    
     // パスに ".." が含まれる場合は、std::filesystem の機能を使って適用します。
-    fs::path TexturePathCpp = fs::u8path(TCHAR_TO_UTF8(*TexturePath_NotNormalized)).lexically_normal();
-    const FString TexturePath = TexturePathCpp.c_str();
+    fs::path TexturePathCpp = fs::u8path(TCHAR_TO_UTF8(*TexturePath_SlashOrBackSlash)).lexically_normal();
+    const FString TexturePath_Normalized = TexturePathCpp.c_str();
+    // 引数のパスのセパレーターはOSによって "/" か "¥" なので "/" に統一します。
+    const auto TexturePath = TexturePath_Normalized.Replace(*FString("\\"), *FString("/"));
 
     if (!TryLoadAndUncompressImageFile(TexturePath, UncompressedData, Width, Height, PixelFormat))
         return nullptr;
@@ -192,7 +193,7 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
                 const auto BaseDir = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*(FPaths::ProjectContentDir() + "PLATEAU/"));
                 auto TextureRelativePath = TexturePath.Replace(*BaseDir, *FString(""));
                 DesiredTextureName = TextureRelativePath;
-                FString NewUniqueName = DesiredTextureName;
+                FString NewUniqueName = DesiredTextureName.Replace(*FString("\\"), *FString("/"));
                 if (!NewTexture->Rename(*NewUniqueName, nullptr, REN_Test)) {
                     NewUniqueName = MakeUniqueObjectName(Package, USceneComponent::StaticClass(), FName(DesiredTextureName)).ToString();
                 }

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -214,15 +214,14 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
                 NewTexture->Source.Init(Width, Height, 1, 1, ETextureSourceFormat::TSF_BGRA8, UncompressedData.GetData());
 
                 // TODO: 関数化(SaveTexturePackage)
-                //Package->MarkPackageDirty();
-                //FAssetRegistryModule::AssetCreated(NewTexture);
-
-                //const FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
-                //FSavePackageArgs Args;
-                //Args.SaveFlags = SAVE_NoError;
-                //Args.TopLevelFlags = EObjectFlags::RF_Public | EObjectFlags::RF_Standalone;
-                //Args.Error = GError;
-                //UPackage::SavePackage(Package, NewTexture, *PackageFileName, Args);
+                Package->MarkPackageDirty();
+                FAssetRegistryModule::AssetCreated(NewTexture);
+                const FString PackageFileName = FPackageName::LongPackageNameToFilename(PackageName, FPackageName::GetAssetPackageExtension());
+                FSavePackageArgs Args;
+                Args.SaveFlags = SAVE_NoError;
+                Args.TopLevelFlags = EObjectFlags::RF_Public | EObjectFlags::RF_Standalone;
+                Args.Error = GError;
+                UPackage::SavePackage(Package, NewTexture, *PackageFileName, Args);
 
             }, TStatId(), nullptr, ENamedThreads::GameThread)
             ->Wait();

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -175,7 +175,6 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
     {
         FFunctionGraphTask::CreateAndDispatchWhenReady(
             [&]() {
-                auto DesiredTextureName = FPaths::GetBaseFilename(TexturePath);
 
                 FString PackageName = TEXT("/Game/PLATEAU/Textures/");
                 PackageName += FPaths::GetBaseFilename(TexturePath);
@@ -189,13 +188,11 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
                 NewTexture = NewObject<UTexture2D>(Package, NAME_None, RF_Public | RF_Standalone | RF_MarkAsRootSet);
 
                 // テクスチャ名が正しくキャッシュフォルダからの相対パスになるよう変更
-                FString TextureRelativePathPrefix;
-                const auto BaseDir = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*(FPaths::ProjectContentDir() + "PLATEAU/"));
+                const auto BaseDir = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*(FPaths::ProjectContentDir() + FString("PLATEAU/")));
                 auto TextureRelativePath = TexturePath.Replace(*BaseDir, *FString(""));
-                DesiredTextureName = TextureRelativePath;
-                FString NewUniqueName = DesiredTextureName.Replace(*FString("\\"), *FString("/"));
+                FString NewUniqueName = TextureRelativePath.Replace(*FString("\\"), *FString("/"));
                 if (!NewTexture->Rename(*NewUniqueName, nullptr, REN_Test)) {
-                    NewUniqueName = MakeUniqueObjectName(Package, USceneComponent::StaticClass(), FName(DesiredTextureName)).ToString();
+                    NewUniqueName = MakeUniqueObjectName(Package, USceneComponent::StaticClass(), FName(TextureRelativePath)).ToString();
                 }
 
                 NewTexture->Rename(*NewUniqueName, nullptr, REN_DontCreateRedirectors);


### PR DESCRIPTION
## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
[プルリク#83](https://github.com/Synesthesias/PLATEAU-SDK-for-Unreal/pull/83) の修正:  
Macテクスチャ保存のバグ修正

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
