### PR TITLE
Fix/UE5.2でのインポート時クラッシュの修正

### DIFF
--- a/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
@@ -311,24 +311,26 @@ UStaticMeshComponent* FPLATEAUMeshLoader::CreateStaticMeshComponent(
     FMeshDescription* MeshDescription = StaticMesh->CreateMeshDescription(0);
 
     ConvertMesh(InMesh, *MeshDescription);
-    StaticMesh->CommitMeshDescription(0);
+
+    FFunctionGraphTask::CreateAndDispatchWhenReady(
+        [&]() {
+            StaticMesh->CommitMeshDescription(0);
+        }, TStatId(), nullptr, ENamedThreads::GameThread)->Wait();
+
     StaticMeshes.Add(StaticMesh);
     StaticMesh->OnPostMeshBuild().AddLambda(
         [Component](UStaticMesh* Mesh) {
             if (Component == nullptr)
                 return;
-            Async(EAsyncExecution::LargeThreadPool,
+            FFunctionGraphTask::CreateAndDispatchWhenReady(
                 [Component, Mesh] {
-                    FFunctionGraphTask::CreateAndDispatchWhenReady(
-                        [Component, Mesh] {
-                            Component->SetStaticMesh(Mesh);
+                    Component->SetStaticMesh(Mesh);
 
-                            // Collision情報設定
-                            Mesh->CreateBodySetup();
-                            Mesh->GetBodySetup()->CollisionTraceFlag = ECollisionTraceFlag::CTF_UseComplexAsSimple;
+                    // Collision情報設定
+                    Mesh->CreateBodySetup();
+                    Mesh->GetBodySetup()->CollisionTraceFlag = ECollisionTraceFlag::CTF_UseComplexAsSimple;
 
-                        }, TStatId(), nullptr, ENamedThreads::GameThread);
-                });
+                }, TStatId(), nullptr, ENamedThreads::GameThread)->Wait();
         });
 
     FGraphEventRef Task = FFunctionGraphTask::CreateAndDispatchWhenReady([&] {

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -177,7 +177,7 @@ UTexture2D* FPLATEAUTextureLoader::Load(const FString& TexturePath_SlashOrBackSl
             [&]() {
 
                 FString PackageName = TEXT("/Game/PLATEAU/Textures/");
-                PackageName += FPaths::GetBaseFilename(TexturePath);
+                PackageName += FPaths::GetBaseFilename(TexturePath).Replace(TEXT("."), TEXT("_"));
                 UPackage* Package = CreatePackage(*PackageName);
                 Package->FullyLoad();
                 NewTexture = Cast<UTexture2D>(Package->FindAssetInPackage());


### PR DESCRIPTION

## 実装内容
「PLATEAUMeshLoader.cpp」のロード処理に関して、GameThreadへの処理の移行、
および、「PLATEAUTextureLoader.cpp」内で、テクスチャファイルのアセット化処理時、
クラッシュ回避のため、ファイル名に含まれる「.」を「_」に変換する処理を追加しました。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること

## 動作確認
竹芝地区、沼津地区で動作確認いたしました。

## その他
全ての地区に対して検証を行えていないので、問題が発生した時点で修正対応を行います。
