### PR TITLE
範囲選択画面が黒ずんで表示される問題の修正

### DIFF
--- a/Source/PLATEAUEditor/Private/PLATEAUBasemap.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUBasemap.cpp
@@ -27,7 +27,7 @@ namespace {
                         GetTransientPackage(),
                         MeshName, RF_Transient);
 
-                const auto Mat = Cast<UMaterial>(StaticLoadObject(UMaterial::StaticClass(), nullptr, TEXT("/PLATEAU-SDK-for-Unreal/DefaultMaterial")));
+                const auto Mat = Cast<UMaterial>(StaticLoadObject(UMaterial::StaticClass(), nullptr, TEXT("/PLATEAU-SDK-for-Unreal/FeatureInfoPanel_PanelIcon")));
                 const auto DynMat = UMaterialInstanceDynamic::Create(Mat, GetTransientPackage());
                 DynMat->SetTextureParameterValue(TEXT("Texture"), Texture);
                 TileComponent->SetMaterial(0, DynMat);


### PR DESCRIPTION
## 実装内容
タイトル通り。地図のマテリアルをunlitに変更

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
