### PR TITLE
LODアイコンを中心から読み込む

### DIFF
--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.cpp
@@ -88,7 +88,7 @@ namespace {
         FVector Offset{
             XOffset,
             100.0f * RowIndex - 100.0f * RowCount / 2.0f + 50.0f,
-            0.0f
+            1.0f
         };
         Offset *= PanelScaleMultiplier;
         Transform.SetTranslation(Center + Offset);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.cpp
@@ -115,9 +115,6 @@ EPLATEAUFeatureInfoVisibility FPLATEAUAsyncLoadedFeatureInfoPanel::GetFeatureInf
 }
 
 void FPLATEAUAsyncLoadedFeatureInfoPanel::SetFeatureInfoVisibility(const TArray<int>& ShowLods, const EPLATEAUFeatureInfoVisibility Value, const bool bForce) {
-    if (CreateComponentStatus != EPLATEAUFeatureInfoPanelStatus::FullyLoaded)
-        return;
-
     if (FeatureInfoVisibility == Value && !bForce)
         return;
 
@@ -271,9 +268,6 @@ bool FPLATEAUAsyncLoadedFeatureInfoPanel::AddIconComponent(const float DeltaSeco
 }
 
 void FPLATEAUAsyncLoadedFeatureInfoPanel::RecalculateIconTransform(const TArray<int>& ShowLods) {
-    if (CreateComponentStatus != EPLATEAUFeatureInfoPanelStatus::FullyLoaded)
-        return;
-
     const int NumFilteredIconComponents = std::accumulate(FeatureInfoMaterialMaps.begin(), FeatureInfoMaterialMaps.end(), 0, [ShowLods](const int Sum, const FPLATEAUFeatureInfoMaterialKey MaterialKey) {
         return Sum + (ShowLods.Contains(MaterialKey.Lod) ? 1 : 0);
     });

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.cpp
@@ -221,7 +221,7 @@ void FPLATEAUAsyncLoadedFeatureInfoPanel::LoadMaxLodAsync(const FPLATEAUFeatureI
     }, LowLevelTasks::ETaskPriority::BackgroundHigh);
 }
 
-bool FPLATEAUAsyncLoadedFeatureInfoPanel::AddIconComponent(const float DeltaSeconds) {
+bool FPLATEAUAsyncLoadedFeatureInfoPanel::AddIconComponent() {
     if (AddComponentStatus == EPLATEAUFeatureInfoPanelStatus::FullyLoaded)
         return false;
 
@@ -239,30 +239,21 @@ bool FPLATEAUAsyncLoadedFeatureInfoPanel::AddIconComponent(const float DeltaSeco
         CreateComponentStatus = EPLATEAUFeatureInfoPanelStatus::FullyLoaded;
     }
 
-    AddComponentStatus = EPLATEAUFeatureInfoPanelStatus::Loading;
-    DeltaTime = DeltaSeconds + DeltaTime;
-    if (AddPanelComponentSleepTime < DeltaTime && AddedIconComponentCnt < IconComponents.Num()) {
-        DeltaTime = 0;
-
-        check(IconComponents.Num() == DetailedIconComponents.Num());
+    if (AddedIconComponentCnt < IconComponents.Num()) {
         const auto Transform = CalculateIconTransform(Box, AddedIconComponentCnt % plateau::Feature::MaxIconCol, AddedIconComponentCnt / plateau::Feature::MaxIconCol, IconComponents.Num());
         PreviewScene->AddComponent(IconComponents[AddedIconComponentCnt], Transform);
         AddedIconComponentCnt++;
-
         return true;
     }
 
-    if (AddPanelComponentSleepTime < DeltaTime && AddedDetailedIconComponentCnt < DetailedIconComponents.Num()) {
-        DeltaTime = 0;
-
+    if (AddedDetailedIconComponentCnt < DetailedIconComponents.Num()) {
         const auto Transform = CalculateIconTransform(Box, AddedDetailedIconComponentCnt % plateau::Feature::MaxIconCol, AddedDetailedIconComponentCnt / plateau::Feature::MaxIconCol, IconComponents.Num());
         PreviewScene->AddComponent(DetailedIconComponents[AddedDetailedIconComponentCnt], Transform);
-        const auto IconCnt = FMath::Min(DetailedIconComponents.Num(), plateau::Feature::MaxIconCnt);
-        if (IconCnt - 1 <= AddedDetailedIconComponentCnt++)
-            AddComponentStatus = EPLATEAUFeatureInfoPanelStatus::FullyLoaded;
-
+        AddedDetailedIconComponentCnt++;
         return true;
     }
+
+    AddComponentStatus = EPLATEAUFeatureInfoPanelStatus::FullyLoaded;
 
     return false;
 }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.h
@@ -60,7 +60,7 @@ public:
     /**
      * @brief アイコンコンポーネント追加
      */
-    bool AddIconComponent(float DeltaSeconds);
+    bool AddIconComponent();
 
     int GetIconCount() const {
         return IconComponents.Num();

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -2,9 +2,6 @@
 
 #include "ExtentEditor/PLATEAUExtentEditor.h"
 
-#include "EditorViewportTabContent.h"
-#include "Engine/Selection.h"
-#include "Misc/ScopedSlowTask.h"
 #include "Algo/AnyOf.h"
 
 #include "PLATEAUEditor.h"
@@ -44,13 +41,12 @@ TSharedRef<SDockTab> FPLATEAUExtentEditor::SpawnTab(const FSpawnTabArgs& Args) {
     Viewport->SetOwnerTab(DockableTab);
     DockableTab->SetOnTabClosed(SDockTab::FOnTabClosedCallback::CreateLambda([](TSharedRef<SDockTab> DockTab) {
         const auto& Window = IPLATEAUEditorModule::Get().GetWindow();
-        const auto& EditorUtilityWidget = dynamic_cast<UPLATEAUSDKEditorUtilityWidget*>(Window->GetEditorUtilityWidget());
-        if (EditorUtilityWidget != nullptr) {
-            const auto& PLATEAUSDKEditorUtilityWidget = dynamic_cast<UPLATEAUSDKEditorUtilityWidget*>(EditorUtilityWidget);
-            if (PLATEAUSDKEditorUtilityWidget != nullptr) {
-                PLATEAUSDKEditorUtilityWidget->CloseAreaSelectionWindowInvoke();
-            }
+        if (const auto& Euw = Window->GetEditorUtilityWidget(); Euw != nullptr) {
+            if (const auto& PlateauEuw = dynamic_cast<UPLATEAUSDKEditorUtilityWidget*>(Euw); PlateauEuw != nullptr) {
+                PlateauEuw->CloseAreaSelectionWindowInvoke();
+            }            
         }
+
     }));
 
     return DockableTab;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -17,7 +17,7 @@
 const FName FPLATEAUExtentEditor::TabId(TEXT("PLATEAUExtentEditor"));
 
 void FPLATEAUExtentEditor::RegisterTabSpawner(const TSharedRef<class FTabManager>& InTabManager) {
-    InTabManager->RegisterTabSpawner(TabId, FOnSpawnTab::CreateSP(this, &FPLATEAUExtentEditor::SpawnTab))
+    InTabManager->RegisterTabSpawner(TabId, FOnSpawnTab::CreateRaw(this, &FPLATEAUExtentEditor::SpawnTab), FCanSpawnTab::CreateRaw(this, &FPLATEAUExtentEditor::CanSpawnTab))
         .SetDisplayName(LOCTEXT("ViewportTab", "Viewport"))
         .SetIcon(FSlateIcon(FAppStyle::GetAppStyleSetName(), "LevelEditor.Tabs.Viewports"));
 }
@@ -49,6 +49,11 @@ TSharedRef<SDockTab> FPLATEAUExtentEditor::SpawnTab(const FSpawnTabArgs& Args) {
     }));
 
     return DockableTab;
+}
+
+bool FPLATEAUExtentEditor::CanSpawnTab(const FSpawnTabArgs& Args) const {
+    const auto& UseSourcePath = IsImportFromServer() ? UTF8_TO_TCHAR(GetServerDatasetID().c_str()) : GetSourcePath();
+    return 0 < UseSourcePath.Len();
 }
 
 const FString& FPLATEAUExtentEditor::GetSourcePath() const {

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -46,7 +46,6 @@ TSharedRef<SDockTab> FPLATEAUExtentEditor::SpawnTab(const FSpawnTabArgs& Args) {
                 PlateauEuw->CloseAreaSelectionWindowInvoke();
             }            
         }
-
     }));
 
     return DockableTab;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
@@ -185,7 +185,7 @@ void FPLATEAUExtentEditorViewportClient::DrawCanvas(FViewport& InViewport, FScen
     if (NearestMeshCodeGizmo.GetRegionMeshID() != "" && LoadingPanelCnt < MaxLoadPanelParallelCount && 0 < CameraDistance && CameraDistance < 9000.0) {
         FeatureInfoDisplay->CreatePanelAsync(NearestMeshCodeGizmo, *DatasetAccessor);
     }
-    
+
     for (const auto& MeshCodeGizmo : MeshCodeGizmos) {
         if (const auto ItemCount = FeatureInfoDisplay.Get()->GetItemCount(MeshCodeGizmo); 0 < ItemCount) {
             MeshCodeGizmo.DrawRegionMeshID(InViewport, View, Canvas, MeshCodeGizmo.GetRegionMeshID(), CameraDistance, ItemCount);
@@ -193,9 +193,9 @@ void FPLATEAUExtentEditorViewportClient::DrawCanvas(FViewport& InViewport, FScen
 
         FeatureInfoDisplay->AddComponent(MeshCodeGizmo);
 
-        if (CameraDistance < 4000.0) {
+        if (CameraDistance < plateau::geometry::ShowFeatureDetailIconCameraDistance) {
             FeatureInfoDisplay->SetVisibility(MeshCodeGizmo, EPLATEAUFeatureInfoVisibility::Detailed);
-        } else if (CameraDistance < 9000.0) {
+        } else if (CameraDistance < plateau::geometry::ShowFeatureIconCameraDistance) {
             FeatureInfoDisplay->SetVisibility(MeshCodeGizmo, EPLATEAUFeatureInfoVisibility::Visible);
         } else {
             FeatureInfoDisplay->SetVisibility(MeshCodeGizmo, EPLATEAUFeatureInfoVisibility::Hidden);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -19,16 +19,15 @@ namespace plateau::dataset {
 /** Viewport Client for the preview viewport */
 class FPLATEAUExtentEditorViewportClient : public FEditorViewportClient, public TSharedFromThis<FPLATEAUExtentEditorViewportClient> {
 public:
-    FPLATEAUExtentEditorViewportClient(
-        TWeakPtr<class FPLATEAUExtentEditor> InExtentEditor,
-        const TSharedRef<class SPLATEAUExtentEditorViewport>& InPLATEAUExtentEditorViewport,
-        const TSharedRef<class FAdvancedPreviewScene>& InPreviewScene);
+    FPLATEAUExtentEditorViewportClient(const TWeakPtr<class FPLATEAUExtentEditor>& InExtentEditor,
+                                       const TSharedRef<class SPLATEAUExtentEditorViewport>& InPLATEAUExtentEditorViewport,
+                                       const TSharedRef<class FAdvancedPreviewScene>& InPreviewScene);
     virtual ~FPLATEAUExtentEditorViewportClient() override;
 
     /**
      * @brief ViewportのConstructから呼び出される初期化処理です。
      */
-    void Initialize(std::shared_ptr<plateau::dataset::IDatasetAccessor> InFileCollection);
+    void Initialize(const std::shared_ptr<plateau::dataset::IDatasetAccessor>& InFileCollection);
 
     /**
      * @brief 選択状態を初期化

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -68,8 +68,9 @@ private:
     FVector TrackingStartedCameraPosition;
     TArray<class FPLATEAUMeshCodeGizmo> MeshCodeGizmos;
     
-    bool GizmoContains(const FPLATEAUMeshCodeGizmo Gizmo) const;
+    bool GizmoContains(const FPLATEAUMeshCodeGizmo& Gizmo) const;
     FVector GetWorldPosition(uint32 X, uint32 Y);
     bool TryGetWorldPositionOfCursor(FVector& Position);
     void InitCamera();
+    FPLATEAUMeshCodeGizmo GetNearestMeshCodeGizmo();
 };

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -132,7 +132,7 @@ int FPLATEAUFeatureInfoDisplay::CountLoadingPanels() {
 
 bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
     if (MeshCodeGizmoContains(MeshCodeGizmo)) {
-        return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->AddIconComponent(0.016f);
+        return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->AddIconComponent();
     }
 
     return false;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -121,15 +121,6 @@ bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUMeshCodeGizmo& M
     return true;
 }
 
-int FPLATEAUFeatureInfoDisplay::CountLoadingPanels() {
-    int Count = 0;
-    for (const auto& Entry : AsyncLoadedPanels) {
-        if (Entry.Value->GetLoadMaxLodTaskStatus() == EPLATEAUFeatureInfoPanelStatus::Loading)
-            ++Count;
-    }
-    return Count;
-}
-
 bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
     if (MeshCodeGizmoContains(MeshCodeGizmo)) {
         return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->AddIconComponent(0.016f);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -99,7 +99,7 @@ FPLATEAUFeatureInfoDisplay::~FPLATEAUFeatureInfoDisplay() {}
 
 bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const IDatasetAccessor& InDatasetAccessor) {
     // 生成済みの場合はスキップ
-    if (AsyncLoadedPanels.Find(MeshCodeGizmo.GetRegionMeshID()))
+    if (MeshCodeGizmoContains(MeshCodeGizmo))
         return false;
 
     const auto AsyncLoadedTile = MakeShared<FPLATEAUAsyncLoadedFeatureInfoPanel>(SharedThis(this), ViewportClient);
@@ -131,7 +131,7 @@ int FPLATEAUFeatureInfoDisplay::CountLoadingPanels() {
 }
 
 bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
-    if (AsyncLoadedPanels.Contains(MeshCodeGizmo.GetRegionMeshID())) {
+    if (MeshCodeGizmoContains(MeshCodeGizmo)) {
         return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->AddIconComponent(0.016f);
     }
 
@@ -154,11 +154,11 @@ EPLATEAUFeatureInfoVisibility FPLATEAUFeatureInfoDisplay::GetVisibility() const 
     return Visibility;
 }
 
-void FPLATEAUFeatureInfoDisplay::SetVisibility(const FPLATEAUMeshCodeGizmo& Gizmo, const EPLATEAUFeatureInfoVisibility Value) {
+void FPLATEAUFeatureInfoDisplay::SetVisibility(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value) {
     Visibility = Value;
-    if (AsyncLoadedPanels.Contains(Gizmo.GetRegionMeshID())) {
-        AsyncLoadedPanels[Gizmo.GetRegionMeshID()].Get()->RecalculateIconTransform(ShowLods);
-        AsyncLoadedPanels[Gizmo.GetRegionMeshID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility);
+    if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+        AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->RecalculateIconTransform(ShowLods);
+        AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility);
     }
 }
 
@@ -230,10 +230,10 @@ void FPLATEAUFeatureInfoDisplay::SwitchFeatureInfoDisplay(const TArray<FPLATEAUM
         ShowLods.Remove(Lod);
     }
 
-    for (const auto& Gizmo : MeshCodeGizmos) {
-        if (AsyncLoadedPanels.Contains(Gizmo.GetRegionMeshID())) {
-            AsyncLoadedPanels[Gizmo.GetRegionMeshID()].Get()->RecalculateIconTransform(ShowLods);
-            AsyncLoadedPanels[Gizmo.GetRegionMeshID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility, true);
+    for (const auto& MeshCodeGizmo : MeshCodeGizmos) {
+        if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+            AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->RecalculateIconTransform(ShowLods);
+            AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility, true);
         }
     }
 }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -121,6 +121,15 @@ bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUMeshCodeGizmo& M
     return true;
 }
 
+int FPLATEAUFeatureInfoDisplay::CountLoadingPanels() {
+    int Count = 0;
+    for (const auto& Entry : AsyncLoadedPanels) {
+        if (Entry.Value->GetLoadMaxLodTaskStatus() == EPLATEAUFeatureInfoPanelStatus::Loading)
+            ++Count;
+    }
+    return Count;
+}
+
 bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
     if (MeshCodeGizmoContains(MeshCodeGizmo)) {
         return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->AddIconComponent(0.016f);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
@@ -64,8 +64,6 @@ public:
     bool CreatePanelAsync(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const plateau::dataset::IDatasetAccessor& InDatasetAccessor);
     bool AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo);
 
-    int CountLoadingPanels();
-
     UMaterialInstanceDynamic* GetFeatureInfoIconMaterial(const FPLATEAUFeatureInfoMaterialKey& Key);
     UMaterialInstanceDynamic* GetBackPanelMaterial() const;
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
@@ -64,6 +64,8 @@ public:
     bool CreatePanelAsync(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const plateau::dataset::IDatasetAccessor& InDatasetAccessor);
     bool AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo);
 
+    int CountLoadingPanels();
+
     UMaterialInstanceDynamic* GetFeatureInfoIconMaterial(const FPLATEAUFeatureInfoMaterialKey& Key);
     UMaterialInstanceDynamic* GetBackPanelMaterial() const;
 

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
@@ -77,7 +77,7 @@ public:
     /**
      * @brief 地物情報パネルの可視性を設定します。
      */
-    void SetVisibility(const FPLATEAUMeshCodeGizmo& Gizmo, const EPLATEAUFeatureInfoVisibility Value);
+    void SetVisibility(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value);
 
     /**
      * @brief 範囲選択画面に表示する各パッケージリストを取得
@@ -94,9 +94,13 @@ public:
      */  
     static TArray<FString> GetIconFileNameList();
 
-    int GetItemCount(const FString& RegionMeshID) {
-        if (AsyncLoadedPanels.Contains(RegionMeshID)) {
-            return AsyncLoadedPanels[RegionMeshID].Get()->GetIconCount();
+    bool MeshCodeGizmoContains(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) const {
+        return AsyncLoadedPanels.Contains(MeshCodeGizmo.GetRegionMeshID());
+    }
+    
+    int GetItemCount(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
+        if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+            return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->GetIconCount();
         }
         return 0;
     }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
@@ -12,7 +12,6 @@
 #include "Algo/AnyOf.h"
 #include "Engine/Font.h"
 #include "Materials/MaterialInstanceDynamic.h"
-#include "Materials/MaterialRenderProxy.h"
 
 namespace {
     bool IsLevel4OrAbove(const plateau::dataset::MeshCode& MeshCode) {
@@ -137,12 +136,8 @@ void FPLATEAUMeshCodeGizmo::DrawExtent(const FSceneView* View, FPrimitiveDrawInt
 
 void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& RegionMeshID,
                                              double CameraDistance, int IconCount) const {
-
     if (IsLevel4OrAbove(MeshCode)) return;
-
-    constexpr auto NearOffset = 8000;
-    constexpr auto FarOffset = 100000;
-
+    
     const auto CenterX = MinX + (MaxX - MinX) / 2;
     const auto Coef = 4 < IconCount ? 1.52 : 1.28;
     const auto CenterY = MinY + (MaxY - MinY) / 2 * Coef;
@@ -164,7 +159,7 @@ void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(const FViewport& InViewport, const 
     const auto Color = FColor::Blue;
 
     if (ViewPlane.W > 0.f) {
-        if (CameraDistance <= NearOffset) {
+        if (CameraDistance < plateau::geometry::ShowRegionMeshIdCameraDistance) {
             Canvas.DrawShadowedText(XPos - HalfWidth, YPos - HalfHeight, FText::FromString(RegionMeshID), ViewFont, Color);
         }
     }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
@@ -8,6 +8,9 @@
 namespace plateau {
     namespace geometry {
         class GeoReference;
+        constexpr auto ShowFeatureDetailIconCameraDistance = 4000;
+        constexpr auto ShowFeatureIconCameraDistance = 9000;
+        constexpr auto ShowRegionMeshIdCameraDistance = 9000;
     }
 }
 

--- a/Source/PLATEAUEditor/Private/PLATEAUWindow.cpp
+++ b/Source/PLATEAUEditor/Private/PLATEAUWindow.cpp
@@ -83,6 +83,8 @@ TSharedRef<SDockTab> FPLATEAUWindow::SpawnTab(const FSpawnTabArgs& TabSpawnArgs)
 }
 
 UEditorUtilityWidget* FPLATEAUWindow::GetEditorUtilityWidget() const {
+    if (!EditorUtilityWidgetBlueprint.IsValid())
+        return nullptr;
     return EditorUtilityWidgetBlueprint->GetCreatedWidget();
 }
 

--- a/Source/PLATEAUEditor/Public/ExtentEditor/PLATEAUExtentEditor.h
+++ b/Source/PLATEAUEditor/Public/ExtentEditor/PLATEAUExtentEditor.h
@@ -29,6 +29,7 @@ public:
     void UnregisterTabSpawner(const TSharedRef<class FTabManager>& TabManager);
 
     TSharedRef<SDockTab> SpawnTab(const FSpawnTabArgs& Args);
+    bool CanSpawnTab(const FSpawnTabArgs& Args) const;
 
     const FString& GetSourcePath() const;
     void SetSourcePath(const FString& Path);


### PR DESCRIPTION
## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
・範囲選択ウィンドウ表示時のLODアイコン読み込み開始位置を画面中央に変更しました。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
