### PR TITLE
道路ネットワーク生成(レーン分割)

### DIFF
--- a/Source/PLATEAURuntime/Private/RoadNetwork/CityObject/SubDividedCityObjectFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/CityObject/SubDividedCityObjectFactory.cpp
@@ -1,11 +1,7 @@
 // Copyright © 2023 Ministry of Land, Infrastructure and Transport
 #include "RoadNetwork/CityObject/SubDividedCityObjectFactory.h"
-#include "BlueprintActionDatabase.h"
 #include "PLATEAUExportSettings.h"
 #include "PLATEAUMeshExporter.h"
-#include "UObject/FastReferenceCollector.h"
-#include <plateau/granularity_convert/granularity_converter.h>
-
 #include "CityGML/PLATEAUCityObject.h"
 #include "Reconstruct/PLATEAUModelReconstruct.h"
 #include "Util/PLATEAUReconstructUtil.h"

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -788,18 +788,20 @@ TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRnModel(
                     {
                         Parent = ParentPair->Value->Node;
                     }
-
-                    if (auto road = Parent->CastToRoad()) {
-                        auto&& way = road->GetMergedSideWay(EPLATEAURnDir::Left);
-                        if (insideWay != nullptr) {
-                            // #NOTE : 自動生成の段階だと線分共通なので同一判定でチェックする
-                            // #TODO : 自動生成の段階で分かれているケースが存在するならは点や法線方向で判定するように変える
-                            if (way == nullptr)
-                                laneType = EPLATEAURnSideWalkLaneType::Undefined;
-                            else if (insideWay->IsSameLineReference(way))
-                                laneType = EPLATEAURnSideWalkLaneType::LeftLane;
-                            else
-                                laneType = EPLATEAURnSideWalkLaneType::RightLane;
+                    if(Parent)
+                    {
+                        if (auto road = Parent->CastToRoad()) {
+                            auto&& way = road->GetMergedSideWay(EPLATEAURnDir::Left);
+                            if (insideWay != nullptr) {
+                                // #NOTE : 自動生成の段階だと線分共通なので同一判定でチェックする
+                                // #TODO : 自動生成の段階で分かれているケースが存在するならは点や法線方向で判定するように変える
+                                if (way == nullptr)
+                                    laneType = EPLATEAURnSideWalkLaneType::Undefined;
+                                else if (insideWay->IsSameLineReference(way))
+                                    laneType = EPLATEAURnSideWalkLaneType::LeftLane;
+                                else
+                                    laneType = EPLATEAURnSideWalkLaneType::RightLane;
+                            }
                         }
                     }
 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -18,6 +18,7 @@
 #include "RoadNetwork/Structure/RnSideWalk.h"
 #include "RoadNetwork/Structure/RnLineString.h"
 #include "RoadNetwork/Structure/RnWay.h"
+#include "RoadNetwork/Util/PLATEAURnLinq.h"
 
 
 const FString FRoadNetworkFactory::FactoryVersion = TEXT("1.0.0");
@@ -589,7 +590,7 @@ namespace
             auto V1 = Vertices[(i + 1) % Vertices.Num()];
 
             TObjectPtr<UREdge> E;                
-            if(FPLATEAURnEx::TryFirstOrDefault(
+            if(FPLATEAURnLinq::TryFirstOrDefault(
                 V0->GetEdges()
                 , [V0, V1](TObjectPtr<UREdge> E)-> bool {
                     return E->IsSameVertex(V0, V1);
@@ -839,9 +840,9 @@ TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRnModel(
         //    ret.CalibrateIntersectionBorderForAllRoad(CalibrateIntersectionOption);
         //}
 
-        //// 道路を分割する
-        //ret->SplitLaneByWidth(RoadSize, false, out auto&& failedLinks);
-        //ret->ReBuildIntersectionTracks();
+        // 道路を分割する
+        TArray<FString> FailedRoads;
+        Model->SplitLaneByWidth(Self.RoadSize, false, FailedRoads);
 
         //// 信号制御器をデフォ値で配置する
         //if (AddTrafficSignalLights)

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -117,10 +117,12 @@ namespace
                     return FRRoadTypeMaskEx::HasAnyFlag(Face->GetRoadTypes(), ERRoadTypeMask::SideWalk) == false;
             });
 
-            if (FGeoGraph2D::IsClockwise<RGraphRef_t<URVertex>>(Vertices, [](RGraphRef_t<URVertex> v)
-            {
+            if (FGeoGraph2D::IsClockwise<RGraphRef_t<URVertex>>(
+                Vertices
+                , [](RGraphRef_t<URVertex> v){
                     return FPLATEAURnDef::To2D(v->Position);
-            })) {
+            }) == false) 
+            {
                 Algo::Reverse(Vertices);
             }
         }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -675,8 +675,11 @@ void FRoadNetworkFactoryEx::CreateRnModel(const FRoadNetworkFactory& Self, APLAT
     auto res = CreateRoadNetwork(Self, Actor, DestActor, CityObjectGroups);
 }
 
-TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRoadNetwork(const FRoadNetworkFactory& Self, APLATEAUInstancedCityModel* TargetCityModel, APLATEAURnStructureModel* Actor,
-                                                        TArray<UPLATEAUCityObjectGroup*>& CityObjectGroups)
+TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRoadNetwork(
+    const FRoadNetworkFactory& Self
+    , APLATEAUInstancedCityModel* TargetCityModel
+    , APLATEAURnStructureModel* Actor
+    , TArray<UPLATEAUCityObjectGroup*>& CityObjectGroups)
 {
 #if WITH_EDITOR
     const auto Root = Actor->GetRootComponent();
@@ -685,7 +688,13 @@ TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRoadNetwork(const FRoadNetworkFa
 
     RGraphRef_t<URGraph> Graph;
     CreateRGraph(Self, TargetCityModel, Actor, Root, SubDividedCityObjects, Graph);
-    Actor->Model = CreateRnModel(Self, Graph);
+
+    const auto RnModelObjectName = TEXT("RnModel");
+
+    auto Model
+    = FPLATEAURnEx::GetOrCreateInstanceComponentWithName<URnModel>(Actor, Root, RnModelObjectName);
+    
+    Actor->Model = CreateRnModel(Self, Graph, Model);
     return Actor->Model;
 #else
     return nullptr;
@@ -694,9 +703,13 @@ TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRoadNetwork(const FRoadNetworkFa
 
 TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRnModel(
     const FRoadNetworkFactory& Self
-    , RGraphRef_t<URGraph> Graph)
+    , RGraphRef_t<URGraph> Graph
+    , URnModel* Model
+)
 {
-    auto Model = RnNew<URnModel>();
+    if (!Model)
+        return Model;
+    Model->Init();
     try {
         // 道路/中央分離帯は一つのfaceGroupとしてまとめる
         auto&& mask = ~(ERRoadTypeMask::Road | ERRoadTypeMask::Median);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -2,7 +2,6 @@
 
 #include <plateau/dataset/i_dataset_accessor.h>
 
-#include "Editor.h"
 #include "Algo/Count.h"
 #include "RoadNetwork/CityObject/PLATEAUSubDividedCityObjectGroup.h"
 #include "RoadNetwork/CityObject/SubDividedCityObjectFactory.h"

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -36,13 +36,20 @@ namespace
         Isolated
     };
 
+    // 輪郭線分構造
     class FTranLine {
     public:
+        // 隣接している道路
         FTran* Neighbor;
+        // 線分リスト
         TArray<RGraphRef_t<UREdge>> Edges;
+        // 頂点リスト
         TArray<RGraphRef_t<URVertex>> Vertices;
+        // 線分リストをRnWayに変換したもの
         TRnRef_T<URnWay> Way;
+        // 次の輪郭線分
         TSharedPtr<FTranLine> Next;
+        // ひとつ前の輪郭線分
         TSharedPtr<FTranLine> Prev;
 
         bool IsBorder() const {
@@ -50,13 +57,16 @@ namespace
         }
     };
 
+    // 道路構造に対応
     class FTran {
     public:
         FWork& Work;
         RGraphRef_t<URGraph> Graph;
         TSet<RGraphRef_t<URFace>> Roads;
         RGraphRef_t<URFaceGroup> FaceGroup;
+        // 輪郭の頂点配列
         TArray<RGraphRef_t<URVertex>> Vertices;
+        // 輪郭の線分配列
         TArray<TSharedPtr<FTranLine>> Lines;
         TRnRef_T<URnRoadBase> Node;
         TArray<TRnRef_T<URnLane>> Lanes;
@@ -832,7 +842,9 @@ TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRnModel(
         //}
 
         // 連続した道路を一つにまとめる
-        Model->MergeRoadGroup();
+        if (Self.bMergeRoadGroup) {
+            Model->MergeRoadGroup();
+        }
 
 
         //// 交差点との境界線が垂直になるようにする
@@ -842,12 +854,7 @@ TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRnModel(
 
         // 道路を分割する
         TArray<FString> FailedRoads;
-        Model->SplitLaneByWidth(Self.RoadSize, false, FailedRoads);
-
-        //// 信号制御器をデフォ値で配置する
-        //if (AddTrafficSignalLights)
-        //    ret.AddDefaultTrafficSignalLights();
-        
+        Model->SplitLaneByWidth(Self.RoadSize, false, FailedRoads);        
     }
     catch(std::exception e)
     {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment2D.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment2D.cpp
@@ -1,6 +1,7 @@
 #include "RoadNetwork/GeoGraph/LineSegment2D.h"
 
 #include "RoadNetwork/GeoGraph/LineUtil.h"
+#include "RoadNetwork/Util/PLATEAUVector2DEx.h"
 
 FLineSegment2D::FLineSegment2D(const FVector2D& InStart, const FVector2D& InEnd)
     : Start(InStart)
@@ -89,6 +90,11 @@ float FLineSegment2D::GetDistance(const FLineSegment2D& Other) const {
 }
 
 int32 FLineSegment2D::Sign(const FVector2D& Point) const {
-    const float Cross = Direction.X * (Point.Y - Start.Y) - Direction.Y * (Point.X - Start.X);
+    const float Cross = FPLATEAUVector2DEx::Cross(Direction, Point - Start);
     return FMath::Sign(Cross);
+}
+
+bool FLineSegment2D::IsPointOnLeftSide(const FVector2D& Point) const
+{
+    return FPLATEAUVector2DEx::IsPointOnLeftSide(Direction, Point - Start);
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineUtil.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineUtil.cpp
@@ -1,5 +1,7 @@
 #include "RoadNetwork/GeoGraph/LineUtil.h"
 
+#include "RoadNetwork/Util/PLATEAUVector2DEx.h"
+
 FLine::FLine(const FVector& InP0, const FVector& InP1)
     : P0(InP0), P1(InP1) {
 }
@@ -21,16 +23,13 @@ bool FLineUtil::LineIntersection(const FVector2D& A, const FVector2D& B, const F
     OutT1 = OutT2 = 0.0f;
     OutIntersection = FVector2D::ZeroVector;
 
-    const FVector2D Deno = FVector2D(B.X - A.X, B.Y - A.Y);
-    const FVector2D DenoPerp = FVector2D(-Deno.Y, Deno.X);
-    const float Cross = FVector2D::DotProduct(D - C, DenoPerp);
-
-    if (FMath::Abs(Cross) < Epsilon) {
+    const auto Deno = FPLATEAUVector2DEx::Cross(B - A, D - C);
+    if (FMath::Abs(Deno) < Epsilon) {
         return false;
     }
 
-    OutT1 = FVector2D::DotProduct(C - A, D - C) / Cross;
-    OutT2 = FVector2D::DotProduct(B - A, A - C) / Cross;
+    OutT1 = FPLATEAUVector2DEx::Cross(C - A, D - C) / Deno;
+    OutT2 = FPLATEAUVector2DEx::Cross(B - A, A - C) / Deno;
     OutIntersection = FMath::Lerp(A, B, OutT1);
     return true;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/PLATEAURnDef.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/PLATEAURnDef.cpp
@@ -11,6 +11,11 @@ EPLATEAURnDir FPLATEAURnDirEx::GetOpposite(EPLATEAURnDir dir)
     return dir == EPLATEAURnDir::Left ? EPLATEAURnDir::Right : EPLATEAURnDir::Left;
 }
 
+EPLATEAURnLaneBorderDir FPLATEAURnLaneBorderDirEx::GetOpposite(EPLATEAURnLaneBorderDir dir)
+{
+    return dir == EPLATEAURnLaneBorderDir::Left2Right ? EPLATEAURnLaneBorderDir::Right2Left : EPLATEAURnLaneBorderDir::Left2Right;
+}
+
 inline FVector2D FPLATEAURnDef::To2D(const FVector& Vector) {
     return FAxisPlaneEx::ToVector2D(Vector, Plane);
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphEx.cpp
@@ -9,6 +9,7 @@
 #include "RoadNetwork/GeoGraph/GeoGraphEx.h"
 #include "Algo/AnyOf.h"
 #include "RoadNetwork/Util/PLATEAURnDebugEx.h"
+#include "RoadNetwork/Util/PLATEAURnLinq.h"
 
 namespace
 {
@@ -771,7 +772,7 @@ bool FRGraphEx::OutlineVertex2Edge(const TArray<RGraphRef_t<URVertex>>& Vertices
         auto V0 = Vertices[i % Vertices.Num()];
         auto V1 = Vertices[(i + 1) % Vertices.Num()];
         TObjectPtr<UREdge> E;
-        if (FPLATEAURnEx::TryFirstOrDefault(
+        if (FPLATEAURnLinq::TryFirstOrDefault(
             V0->GetEdges()
             , [V0, V1](RGraphRef_t<UREdge> E) { return E->GetOppositeVertex(V0) == V1; }
             , E) == false)

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
@@ -237,7 +237,7 @@ FRnModelDrawIntersectionOption::FRnModelDrawIntersectionOption()
 //    if (bChangeArrowColor)
 //        arrowColor = way.IsReversed ? ReverseWayArrowColor : NormalWayArrowColor;
 //
-//    auto Vertices = FPLATEAURnEx::SelectWithIndex(
+//    auto Vertices = FPLATEAURnLinq::SelectWithIndex(
 //        way.GetVertices()
 //        , [&](FVector v, int32 i) {
 //            return v - work.Self->EdgeOffset * way.GetVertexNormal(i);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnStructureModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnStructureModel.cpp
@@ -12,6 +12,8 @@ void APLATEAURnStructureModel::Tick(float DeltaTime)
 {
     Super::Tick(DeltaTime);
     if (Debug.bVisible) {
+        if(!Model)
+            Model = GetComponentByClass<URnModel>();
         Debug.Draw(Model);
     }
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLane.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLane.cpp
@@ -1,5 +1,7 @@
 #include "RoadNetwork/Structure/RnLane.h"
 
+#include "RoadNetwork/Util/PLATEAUVectorEx.h"
+
 URnLane::URnLane()
     : bIsReverse(false) {
 }
@@ -84,10 +86,32 @@ bool URnLane::IsEmptyLane() const {
 bool URnLane::IsMedianLane() const {
     return GetParent() ? GetParent()->IsMedianLane(RnFrom(this)) : false;
 }
-EPLATEAURnLaneBorderDir URnLane::GetBorderDir(EPLATEAURnLaneBorderType Type) const {
-    return bIsReverse ?
-        (Type == EPLATEAURnLaneBorderType::Prev ? EPLATEAURnLaneBorderDir::Right2Left : EPLATEAURnLaneBorderDir::Left2Right) :
-        (Type == EPLATEAURnLaneBorderType::Prev ? EPLATEAURnLaneBorderDir::Left2Right : EPLATEAURnLaneBorderDir::Right2Left);
+TOptional<EPLATEAURnLaneBorderDir> URnLane::GetBorderDir(EPLATEAURnLaneBorderType Type) const
+{
+    auto Border = GetBorder(Type);
+    if (!Border)
+        return NullOpt;
+    if (!IsValidWay())
+        return NullOpt;
+
+    // とりあえず重なるかで判定
+    // borderの0番目の点がLeftWayの0番目の点と同じならLeft2Right
+    if(Border->GetPoint(0) == LeftWay->GetPoint(0))
+        return EPLATEAURnLaneBorderDir::Left2Right;
+
+    if (Border->GetPoint(0) == RightWay->GetPoint(0))
+        return EPLATEAURnLaneBorderDir::Right2Left;
+
+    if (!Border->IsValid())
+        return NullOpt;
+
+    auto D = Border->GetPoint(1)->Vertex - Border->GetPoint(0)->Vertex;
+    auto Index = Type == EPLATEAURnLaneBorderType::Prev ? 0 : 1;
+    auto D2 = RightWay->GetPoint(Index)->Vertex - LeftWay->GetPoint(Index)->Vertex;
+    if (FVector2d::DotProduct(FPLATEAURnDef::To2D(D), FPLATEAURnDef::To2D(D2)) > 0.f)
+        return EPLATEAURnLaneBorderDir::Left2Right;
+
+    return EPLATEAURnLaneBorderDir::Right2Left;
 }
 
 TRnRef_T<URnWay> URnLane::GetBorder(EPLATEAURnLaneBorderType Type) const {
@@ -156,8 +180,15 @@ float URnLane::CalcMinWidth() const
 void URnLane::Reverse() {
     bIsReverse = !bIsReverse;
     Swap(PrevBorder, NextBorder);
-    if (LeftWay) LeftWay->Reverse(true);
-    if (RightWay) RightWay->Reverse(true);
+    Swap(LeftWay, RightWay);
+    for (auto Way : GetAllWays())
+        Way->Reverse(true);
+}
+
+void URnLane::AlignBorder(EPLATEAURnLaneBorderDir borderDir)
+{
+    AlignBorder(EPLATEAURnLaneBorderType::Prev, borderDir);
+    AlignBorder(EPLATEAURnLaneBorderType::Next, borderDir);
 }
 
 void URnLane::BuildCenterWay() {
@@ -191,36 +222,6 @@ float URnLane::GetCenterLength() const {
     return CenterWay ? CenterWay->CalcLength() : 0.0f;
 }
 
-float URnLane::GetCenterLength2D(EAxisPlane Plane) const {
-    if (!CenterWay) return 0.0f;
-
-    float Length = 0.0f;
-    for (int32 i = 0; i < CenterWay->Count() - 1; ++i) {
-        FVector2D Start = FPLATEAURnDef::To2D(CenterWay->GetPoint(i)->Vertex);
-        FVector2D End = FPLATEAURnDef::To2D(CenterWay->GetPoint(i + 1)->Vertex);
-        Length += FVector2D::Distance(Start, End);
-    }
-    return Length;
-}
-
-float URnLane::GetCenterTotalAngle2D() const {
-    return CenterWay ? CenterWay->LineString->CalcTotalAngle2D() : 0.0f;
-}
-
-float URnLane::GetCenterCurvature2D() const {
-    float Length = GetCenterLength2D();
-    return Length > 0.0f ? GetCenterTotalAngle2D() / Length : 0.0f;
-}
-
-float URnLane::GetCenterRadius2D() const {
-    float Curvature = GetCenterCurvature2D();
-    return Curvature > 0.0f ? 1.0f / Curvature : MAX_FLT;
-}
-
-float URnLane::GetCenterInverseRadius2D() const {
-    return GetCenterCurvature2D();
-}
-
 float URnLane::GetDistanceFrom(const FVector& Point) const {
     if (!IsValidWay()) return MAX_FLT;
 
@@ -238,6 +239,18 @@ bool URnLane::IsInside(const FVector& Point) const {
     return !LeftWay->IsOutSide(Point, Nearest, Distance) &&
         !RightWay->IsOutSide(Point, Nearest, Distance);
 }
+
+
+FVector URnLane::GetCentralVertex() const {
+    TArray<FVector> Points;
+    if (GetLeftWay())
+        Points.Add(GetLeftWay()->GetLerpPoint(0.5f));
+    if (GetRightWay())
+        Points.Add(GetRightWay()->GetLerpPoint(0.5f));
+    return FPLATEAUVectorEx::Centroid(Points);
+}
+
+
 
 TRnRef_T<URnLane> URnLane::Clone() const {
     auto NewLane = RnNew<URnLane>();
@@ -262,3 +275,13 @@ TRnRef_T<URnLane> URnLane::CreateEmptyLane(TRnRef_T<URnWay> border, TRnRef_T<URn
     return ret;
 }
 
+void URnLane::AlignBorder(EPLATEAURnLaneBorderType type, EPLATEAURnLaneBorderDir borderDir)
+{
+    auto border = GetBorder(type);
+    if (!border)
+        return;
+    auto dir = GetBorderDir(type);
+    if (dir != borderDir) {
+        border->Reverse(true);
+    }
+}

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -270,6 +270,9 @@ void URnModel::SplitLaneByWidth(float RoadWidthMeter, bool rebuildTrack, TArray<
             if (RoadGroup->IsValid() == false)
                 continue;
 
+            if (RoadGroup->IsAllLaneValid() == false)
+                continue;
+
             if (RoadGroup->Roads.ContainsByPredicate([](TRnRef_T<URnRoad> l) { return l->MainLanes[0]->HasBothBorder() == false; }))
                 continue;
             auto&& leftCount = RoadGroup->GetLeftLaneCount();

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -158,7 +158,7 @@ void URnModel::CalibrateIntersectionBorder(const FRnModelCalibrateIntersectionBo
             // 道路の長さを取得
             float RoadLength = 0.0f;
             TRnRef_T<URnWay> LeftWay, RightWay;
-            if (Road->TryGetMergedSideWay(std::nullopt, LeftWay, RightWay)) {
+            if (Road->TryGetMergedSideWay(NullOpt, LeftWay, RightWay)) {
                 RoadLength = (LeftWay->CalcLength() + RightWay->CalcLength()) * 0.5f;
             }
 
@@ -236,7 +236,7 @@ void URnModel::MergeRoadGroup()
 {
     TSet<TRnRef_T<URnRoad>> visitedRoads;
     auto CopiedRoads = Roads;
-    for(auto&& road : CopiedRoads)
+    for(auto& road : CopiedRoads)
     {
         if (visitedRoads.Contains(road))
             continue;
@@ -314,4 +314,21 @@ void URnModel::SplitLaneByWidth(float RoadWidthMeter, bool rebuildTrack, TArray<
             failedRoads.Add(Road->GetName());
         }
     }
+}
+
+bool URnModel::Check() const
+{
+    for (auto&& Road : Roads) {
+        if (Road->Check() == false)
+            return false;
+    }
+    for (auto&& Intersection : Intersections) {
+        if (Intersection->Check() == false)
+            return false;
+    }
+    for (auto&& SideWalk : SideWalks) {
+        if (SideWalk->Check() == false)
+            return false;
+    }
+    return true;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -19,6 +19,13 @@ void URnModel::SetFactoryVersion(const FString& InFactoryVersion)
 URnModel::URnModel() {
 }
 
+void URnModel::Init()
+{
+    Roads.Reset();
+    Intersections.Reset();
+    SideWalks.Reset();
+}
+
 void URnModel::AddRoadBase(const TRnRef_T<URnRoadBase>& RoadBase)
 {
     if (!RoadBase) 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
@@ -103,6 +103,26 @@ TArray<TRnRef_T<URnLane>> URnRoad::GetLanes(EPLATEAURnDir Dir) const {
     return Dir == EPLATEAURnDir::Left ? GetLeftLanes() : GetRightLanes();
 }
 
+bool URnRoad::TryGetLanes(TOptional<EPLATEAURnDir> Dir, TArray<TRnRef_T<URnLane>>& OutLanes) const
+{
+    if (Dir.IsSet() == false) {
+        OutLanes = MainLanes;
+        return true;
+    }
+
+    if (EPLATEAURnDir::Left == *Dir) {
+        OutLanes = GetLeftLanes();
+        return true;
+    }
+
+    if (EPLATEAURnDir::Right == *Dir) {
+        OutLanes = GetRightLanes();
+        return true;
+    }
+    return false;
+}
+
+
 bool URnRoad::IsLeftLane(const TRnRef_T<URnLane>& Lane) const {
     return Lane && !Lane->GetIsReverse();
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
@@ -1,5 +1,6 @@
 #include "RoadNetwork/Structure/RnRoad.h"
 
+#include "Algo/AllOf.h"
 #include "Algo/AnyOf.h"
 #include "RoadNetwork/Structure/RnLane.h"
 #include "RoadNetwork/Structure/RnWay.h"
@@ -92,7 +93,7 @@ TArray<TRnRef_T<URnLane>> URnRoad::GetAllLanesWithMedian() const {
 }
 
 bool URnRoad::IsValid() const {
-    return MainLanes.Num() > 0;
+    return MainLanes.Num() > 0 && Algo::AllOf( MainLanes,[](TObjectPtr<URnLane> Lane) { return Lane && Lane->HasBothBorder(); });
 }
 
 bool URnRoad::IsAllBothConnectedLane() const {
@@ -496,7 +497,6 @@ bool FRnRoadEx::IsValidBorderAdjacentNeighbor(const URnRoad* Self, EPLATEAURnLan
         }
 
         auto OppositeLaneBorder = Self->GetBorderWay(Lane, OppositeBorderType, EPLATEAURnLaneBorderDir::Left2Right);
-
 
         // 隣接する道路に共通の境界線を持たない場合はfalse
         if (!Algo::AnyOf(Ways, [LaneBorder](const TRnRef_T<URnWay>& Way) { return Way->IsSameLineReference(LaneBorder); })) 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
@@ -199,17 +199,17 @@ TRnRef_T<URnWay> URnRoad::GetMergedBorder(EPLATEAURnLaneBorderType BorderType, s
     auto Lanes = Dir.has_value() == false ? GetAllLanesWithMedian() : GetLanes(*Dir);
     if (Lanes.Num() == 0) return nullptr;
 
-    auto Border = Lanes[0]->GetBorder(BorderType);
-    if (!Border) return nullptr;
-
-    auto MergedWay = Border->Clone(true);
-    for (int32 i = 1; i < Lanes.Num(); ++i) {
-        auto NextBorder = Lanes[i]->GetBorder(BorderType);
-        if (!NextBorder) continue;
-
-        MergedWay->AppendBack2LineString(NextBorder);
+    auto Ls = RnNew<URnLineString>();
+    for(auto&& Lane : Lanes)
+    {
+        auto Way = GetBorderWay(Lane, BorderType, EPLATEAURnLaneBorderDir::Left2Right);
+        if (!Way)
+            continue;
+        for (auto&& Point : Way->GetPoints()) {
+            Ls->AddPointOrSkip(Point);
+        }
     }
-    return MergedWay;
+    return RnNew<URnWay>(Ls);
 }
 
 TRnRef_T<URnWay> URnRoad::GetMergedSideWay(EPLATEAURnDir Dir) const {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
@@ -207,9 +207,13 @@ void URnRoad::AddMainLane(TRnRef_T<URnLane> Lane)
     MainLanes.Add(Lane);
 }
 
-TRnRef_T<URnWay> URnRoad::GetMergedBorder(EPLATEAURnLaneBorderType BorderType, TOptional<EPLATEAURnDir> Dir) const {
-    auto Lanes = Dir.IsSet() == false ? GetAllLanesWithMedian() : GetLanes(*Dir);
-    if (Lanes.Num() == 0) return nullptr;
+TRnRef_T<URnWay> URnRoad::GetMergedBorder(EPLATEAURnLaneBorderType BorderType, TOptional<EPLATEAURnDir> Dir) const
+{
+    TArray<TRnRef_T<URnLane>> Lanes;
+    if (TryGetLanes(Dir, Lanes) == false)
+        return nullptr;
+    if (Lanes.Num() == 0)
+        return nullptr;
 
     auto Ls = RnNew<URnLineString>();
     for(auto&& Lane : Lanes)
@@ -321,7 +325,8 @@ TRnRef_T<URnWay> URnRoad::GetBorderWay(const TRnRef_T<URnLane>& Lane, EPLATEAURn
     }
 
     auto Border = Lane->GetBorder(BorderType);
-    if (!Border) return nullptr;
+    if (!Border) 
+        return nullptr;
 
     if (Lane->GetBorderDir(BorderType) != BorderDir)
         Border = Border->ReversedWay();

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -259,22 +259,32 @@ bool URnRoadGroup::MergeRoads() {
 
             // 順方向(左車線)
             if (SrcRoad->IsLeftLane(SrcLane)) {
-                DstLane->GetLeftWay()->AppendBack2LineString(SrcLane->GetLeftWay());
-                Visited.Add(DstLane->GetLeftWay()->LineString);
+                if(DstLane->GetLeftWay())
+                {
+                    DstLane->GetLeftWay()->AppendBack2LineString(SrcLane->GetLeftWay());
+                    Visited.Add(DstLane->GetLeftWay()->LineString);                    
+                }
                 if (j == SrcLanes.Num() - 1) {
-                    DstLane->GetRightWay()->AppendBack2LineString(SrcLane->GetRightWay());
-                    Visited.Add(DstLane->GetRightWay()->LineString);
+                    if (DstLane->GetRightWay()) {
+                        DstLane->GetRightWay()->AppendBack2LineString(SrcLane->GetRightWay());
+                        Visited.Add(DstLane->GetRightWay()->LineString);
+                    }
                 }
 
                 DstLane->SetBorder(EPLATEAURnLaneBorderType::Next, SrcLane->GetNextBorder());
             }
             // 逆方向(右車線)
             else {
-                DstLane->GetRightWay()->AppendFront2LineString(SrcLane->GetRightWay());
-                Visited.Add(DstLane->GetRightWay()->LineString);
+                if(DstLane->GetRightWay())
+                {
+                    DstLane->GetRightWay()->AppendFront2LineString(SrcLane->GetRightWay());
+                    Visited.Add(DstLane->GetRightWay()->LineString);                    
+                }
                 if (j == SrcLanes.Num() - 1) {
-                    DstLane->GetLeftWay()->AppendFront2LineString(SrcLane->GetLeftWay());
-                    Visited.Add(DstLane->GetLeftWay()->LineString);
+                    if (DstLane->GetLeftWay()) {
+                        DstLane->GetLeftWay()->AppendFront2LineString(SrcLane->GetLeftWay());
+                        Visited.Add(DstLane->GetLeftWay()->LineString);
+                    }
                 }
 
                 DstLane->SetBorder(EPLATEAURnLaneBorderType::Prev, SrcLane->GetPrevBorder());

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -232,7 +232,6 @@ bool URnRoadGroup::MergeRoads() {
     auto DstLanes = DstRoad->GetAllLanesWithMedian();
     // 配列はコピーして持つ
     auto DstSideWalks = DstRoad->GetSideWalks();
-
     for (int32 i = 1; i < Roads.Num(); i++) {
         // マージ元の道路. DstRoadに統合されて消える
         auto SrcRoad = (Roads)[i];
@@ -357,6 +356,7 @@ bool URnRoadGroup::MergeRoads() {
                     Sw->GetInsideWay() ? Original[InsideWay] : nullptr);
             }
         }
+
         DstRoad->AddTargetTrans(SrcRoad->GetTargetTrans());
         SrcRoad->DisConnect(true);
     }
@@ -367,7 +367,6 @@ bool URnRoadGroup::MergeRoads() {
             NextIntersection->AddEdge(DstRoad, DstRoad->GetBorderWay(Lane, EPLATEAURnLaneBorderType::Next, EPLATEAURnLaneBorderDir::Left2Right));
         }
     }
-
     DstRoad->SetPrevNext(PrevIntersection, NextIntersection);
 
     Roads.Reset();
@@ -557,7 +556,7 @@ void URnRoadGroup::SetLaneCountWithoutMedian(int32 LeftCount, int32 RightCount, 
     Align();
 
     auto Num = LeftCount + RightCount;
-    auto AfterLanes = SplitLane(Num, std::nullopt);
+    auto AfterLanes = SplitLane(Num, NullOpt);
 
     TArray<TRnRef_T<URnLineString>> NewNextBorders;
     TArray<TRnRef_T<URnLineString>> NewPrevBorders;
@@ -624,7 +623,7 @@ void URnRoadGroup::SetLaneCountWithMedian(int32 LeftCount, int32 RightCount, flo
     auto Num = LeftCount + RightCount + 1;
     auto LaneRate = (1.0f - MedianWidthRate) / (Num - 1);
 
-    auto AfterLanes = SplitLane(Num, std::nullopt, [LeftCount, LaneRate, MedianWidthRate](int32 I) {
+    auto AfterLanes = SplitLane(Num, NullOpt, [LeftCount, LaneRate, MedianWidthRate](int32 I) {
         if (I == LeftCount)
             return MedianWidthRate;
         return LaneRate;
@@ -696,12 +695,11 @@ void URnRoadGroup::SetLaneCount(EPLATEAURnDir Dir, int32 Count, bool RebuildTrac
 }
 TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>> URnRoadGroup::SplitLane(
     int32 Num,
-    std::optional<EPLATEAURnDir> Dir,
+    TOptional<EPLATEAURnDir> Dir,
     TFunction<float(int32)> GetSplitRate) {
     if (Num <= 0) 
         return TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>>();
 
-    auto Result = TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>>();
 
     TArray<TRnRef_T<URnWay>> MergedBorders = FPLATEAURnLinq::Select(Roads, [Dir](const TRnRef_T<URnRoad>& Road) {
         return Road->GetMergedBorder(EPLATEAURnLaneBorderType::Prev, Dir);
@@ -716,6 +714,7 @@ TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>> URnRoadGroup::SplitLane(
         BorderWays.Add(Split);
     }
 
+    auto Result = TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>>();
     for (int32 i = 0; i < Roads.Num(); ++i) {
         auto Road = (Roads)[i];
         auto PrevBorders = BorderWays[i];

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -9,10 +9,11 @@
 #include "RoadNetwork/Structure/RnPoint.h"
 #include "RoadNetwork/Util/PLATEAURnDebugEx.h"
 #include "RoadNetwork/Util/PLATEAURnEx.h"
+#include "RoadNetwork/Util/PLATEAURnLinq.h"
 
 URnRoadGroup::URnRoadGroup(TRnRef_T<URnIntersection> InPrevIntersection,
-                         TRnRef_T<URnIntersection> InNextIntersection,
-                         const TArray<TRnRef_T<URnRoad>>& InRoads)
+                           TRnRef_T<URnIntersection> InNextIntersection,
+                           const TArray<TRnRef_T<URnRoad>>& InRoads)
 {
     Init(InPrevIntersection, InNextIntersection, InRoads);
 }
@@ -566,13 +567,13 @@ void URnRoadGroup::SetLaneCountWithoutMedian(int32 LeftCount, int32 RightCount, 
         auto& Lanes = AfterLanes[Road];
 
         if (i == Roads.Num() - 1) {
-            NextIntersection->ReplaceEdges(Road, FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnWay>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
-            NewNextBorders.Append(FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnLineString>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
+            NextIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
+            NewNextBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
         }
 
         if (i == 0) {
-            PrevIntersection->ReplaceEdges(Road, FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnWay>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
-            NewPrevBorders.Append(FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnLineString>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
+            PrevIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
+            NewPrevBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
         }
 
         for (int32 j = LeftCount; j < Lanes.Num(); ++j) {
@@ -638,13 +639,13 @@ void URnRoadGroup::SetLaneCountWithMedian(int32 LeftCount, int32 RightCount, flo
 
         if (i == Roads.Num() - 1) 
         {
-            NextIntersection->ReplaceEdges(Road, FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnWay>>( Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
-            NewNextBorders.Append( FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnLineString>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
+            NextIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select( Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
+            NewNextBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
         }
 
         if (i == 0) {
-            PrevIntersection->ReplaceEdges(Road, FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnWay>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
-            NewPrevBorders.Append(FPLATEAURnEx::Map<TRnRef_T<URnLane>, TRnRef_T<URnLineString>>(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
+            PrevIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
+            NewPrevBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
         }
 
         for (int32 j = LeftCount + 1; j < Lanes.Num(); ++j) {
@@ -702,10 +703,10 @@ TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>> URnRoadGroup::SplitLane(
 
     auto Result = TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>>();
 
-    auto MergedBorders = FPLATEAURnEx::Map<TRnRef_T<URnRoad>, TRnRef_T<URnWay>>(Roads, [Dir](const TRnRef_T<URnRoad>& Road) {
+    TArray<TRnRef_T<URnWay>> MergedBorders = FPLATEAURnLinq::Select(Roads, [Dir](const TRnRef_T<URnRoad>& Road) {
         return Road->GetMergedBorder(EPLATEAURnLaneBorderType::Prev, Dir);
         });
-    MergedBorders.Add((Roads)[Roads.Num() - 1]->GetMergedBorder(EPLATEAURnLaneBorderType::Next, Dir));
+    MergedBorders.Add(Roads.Last()->GetMergedBorder(EPLATEAURnLaneBorderType::Next, Dir));
 
     TArray<TArray<TRnRef_T<URnWay>>> BorderWays;
     BorderWays.Reserve(Roads.Num() + 1);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -40,6 +40,16 @@ bool URnRoadGroup::IsValid() const
     return true;
 }
 
+bool URnRoadGroup::IsAllLaneValid() const
+{
+    for(auto Road : Roads)
+    {
+        if (!Road->IsAllLaneValid())
+            return false;
+    }
+    return true;
+}
+
 int32 URnRoadGroup::GetLeftLaneCount() const {
     Align();
     if (Roads.Num() == 0) return 0;

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnDebugEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnDebugEx.cpp
@@ -18,13 +18,15 @@ void FPLATEAURnDebugEx::DrawLine(const FVector& Start, const FVector& End, const
 void FPLATEAURnDebugEx::DrawArrow(const FVector& Start, const FVector& End, float ArrowSize, const FVector& ArrowUp, const FLinearColor& BodyColor, const FLinearColor& ArrowColor, float Duration, float Thickness) {
     DrawLine(Start, End, BodyColor, Duration, Thickness);
 
-    if (ArrowSize > 0.0f) {
+    if (ArrowSize > 0.0f)
+    {
+        auto Up = FVector::CrossProduct(End - Start, FVector::CrossProduct(End - Start, ArrowUp)).GetSafeNormal();
         const FVector Direction = (End - Start).GetSafeNormal();
         const FVector Right = FVector::CrossProduct(Direction, ArrowUp).GetSafeNormal();
-        const FVector Up = FVector::CrossProduct(Right, Direction).GetSafeNormal();
-
-        const FVector Arrow1 = End - Direction * ArrowSize + Right * ArrowSize;
-        const FVector Arrow2 = End - Direction * ArrowSize - Right * ArrowSize;
+        auto A1 = FQuat(Up, FMath::DegreesToRadians(45.0f)) * (Start - End);
+        auto A2 = FQuat(Up, FMath::DegreesToRadians(-45.0f)) * (Start - End);
+        const FVector Arrow1 = End+ A1.GetSafeNormal() * ArrowSize;
+        const FVector Arrow2 = End+ A2.GetSafeNormal() * ArrowSize;
 
         DrawLine(Arrow1, End, ArrowColor, Duration, Thickness);
         DrawLine(Arrow2, End, ArrowColor, Duration, Thickness);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
@@ -41,6 +41,7 @@ TRnRef_T<URnLineString> FPLATEAURnEx::CreateInnerLerpLineString(
         return RnNew<URnLineString>(Points);
     }
 
+    auto Plane = FPLATEAURnDef::Plane;
     auto Line = RnNew<URnLineString>();
 
     auto AddPoint = [&](TRnRef_T<URnPoint> P) {
@@ -49,7 +50,7 @@ TRnRef_T<URnLineString> FPLATEAURnEx::CreateInnerLerpLineString(
         };
 
     AddPoint(Start);
-    auto Segments = FGeoGraphEx::GetInnerLerpSegments(LeftVertices, RightVertices, FPLATEAURnDef::Plane, T);
+    auto Segments = FGeoGraphEx::GetInnerLerpSegments(LeftVertices, RightVertices, Plane, T);
 
     // 1つ目の点はボーダーと重複するのでスキップ
     for (int32 i = 1; i < Segments.Num(); ++i) {
@@ -59,10 +60,9 @@ TRnRef_T<URnLineString> FPLATEAURnEx::CreateInnerLerpLineString(
     AddPoint(End);
 
     // 自己交差があれば削除する
-    auto Plane = URnModel::Plane;
     FGeoGraph2D::RemoveSelfCrossing<TRnRef_T<URnPoint>>(
         Line->GetPoints(),
-        [Plane](TRnRef_T<URnPoint> T) { return FAxisPlaneEx::GetTangent(T->Vertex, Plane); },
+        [Plane](TRnRef_T<URnPoint> T) { return FAxisPlaneEx::ToVector2D(T->Vertex, Plane); },
         [](TRnRef_T<URnPoint> P1, TRnRef_T<URnPoint> P2, TRnRef_T<URnPoint> P3, TRnRef_T<URnPoint> P4,
             const FVector2D& Inter, float F1, float F2) {
                 return RnNew<URnPoint>(FMath::Lerp(P1->Vertex, P2->Vertex, F1));

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
@@ -49,7 +49,7 @@ TRnRef_T<URnLineString> FPLATEAURnEx::CreateInnerLerpLineString(
         };
 
     AddPoint(Start);
-    auto Segments = FGeoGraphEx::GetInnerLerpSegments(LeftVertices, RightVertices, URnModel::Plane, T);
+    auto Segments = FGeoGraphEx::GetInnerLerpSegments(LeftVertices, RightVertices, FPLATEAURnDef::Plane, T);
 
     // 1つ目の点はボーダーと重複するのでスキップ
     for (int32 i = 1; i < Segments.Num(); ++i) {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
@@ -108,5 +108,7 @@ void FPLATEAURnEx::AddChildInstanceComponent(AActor* Actor, USceneComponent* Par
     Child->SetupAttachment(Parent);
     Child->RegisterComponent();
     Child->AttachToComponent(Parent, TransformRule);
+#if WITH_EDITOR
     Actor->RerunConstructionScripts();
+#endif
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAUVector2DEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAUVector2DEx.cpp
@@ -35,7 +35,12 @@ float FPLATEAUVector2DEx::SignedAngle(const FVector2D& From, const FVector2D& To
 }
 
 float FPLATEAUVector2DEx::Cross(const FVector2D& A, const FVector2D& B) {
-    return A.X * B.Y - A.Y * B.X;
+    return FVector2D::CrossProduct(A, B);
+}
+
+bool FPLATEAUVector2DEx::IsPointOnLeftSide(const FVector2D& From, const FVector2D& To)
+{
+    return Cross(From, To) > 0;
 }
 
 FVector2D FPLATEAUVector2DEx::RotateTo(const FVector2D& From, const FVector2D& To, float MaxRad) {

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Factory/RoadNetworkFactory.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Factory/RoadNetworkFactory.h
@@ -92,9 +92,15 @@ struct FRoadNetworkFactoryEx
 
     static void CreateRnModel(const FRoadNetworkFactory& Self, APLATEAUInstancedCityModel* Actor, APLATEAURnStructureModel* DestActor);
 
-    static TRnRef_T<URnModel> CreateRoadNetwork(const FRoadNetworkFactory& Self, APLATEAUInstancedCityModel* TargetCityModel, APLATEAURnStructureModel* Actor, TArray<UPLATEAUCityObjectGroup*>& CityObjectGroups);
-
 private:
+
+    static TRnRef_T<URnModel> CreateRoadNetwork(
+        const FRoadNetworkFactory& Self
+        , APLATEAUInstancedCityModel* TargetCityModel
+        , APLATEAURnStructureModel* Actor
+        , TArray<UPLATEAUCityObjectGroup*>& CityObjectGroups
+    );
+
     // 最小地物に分解する
     static void CreateSubDividedCityObjects(const FRoadNetworkFactory& Self, APLATEAUInstancedCityModel* Actor
         , AActor* DestActor
@@ -112,5 +118,6 @@ private:
     // RnModelを作成する
     static  TRnRef_T<URnModel> CreateRnModel(
         const FRoadNetworkFactory& Self
-        , RGraphRef_t<URGraph> Graph);
+        , RGraphRef_t<URGraph> Graph
+        , URnModel* OutModel);
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/GeoGraphEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/GeoGraphEx.h
@@ -123,6 +123,23 @@ public:
         return EdgeEnumerator<T>(Vertices, bIsLoop);
     }
 
+    static TArray<FLineSegment3D> GetEdgeSegments(const TArray<FVector>& Vertices, bool bIsLoop)
+    {
+        TArray<FLineSegment3D> Segments;
+        for (auto& Edge : GetEdges(Vertices, bIsLoop)) {
+            Segments.Add(FLineSegment3D(Edge.P0, Edge.P1));
+        }
+        return Segments;    
+    }
+
+    static TArray<FLineSegment2D> GetEdgeSegments(const TArray<FVector2D>& Vertices, bool bIsLoop) {
+        TArray<FLineSegment2D> Segments;
+        for (auto& Edge : GetEdges(Vertices, bIsLoop)) {
+            Segments.Add(FLineSegment2D(Edge.P0, Edge.P1));
+        }
+        return Segments;
+    }
+
    /* template<typename T>
     static TArray<TTuple<T, T>> GetEdges(const TArray<T>& Vertices, bool bIsLoop);*/
 
@@ -130,7 +147,8 @@ public:
         const TArray<FVector>& LeftVertices,
         const TArray<FVector>& RightVertices,
         EAxisPlane Plane,
-        float P);
+        float P,
+        float CheckMeter = 3.f);
 
 
     static TArray<FIntVector> GetNeighborDistance3D(int32 D);

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment2D.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment2D.h
@@ -29,8 +29,12 @@ struct PLATEAURUNTIME_API FLineSegment2D {
     bool TrySegmentIntersection(const FLineSegment2D& Other) const;
 
     float GetDistance(const FLineSegment2D& Other) const;
+
+    // Pointが線分の左側にあれば1, 右側にあれば-1, 線分上にあれば0を返す
     int32 Sign(const FVector2D& Point) const;
 
+    // Pointが線分の左側にあるかどうか
+    bool IsPointOnLeftSide(const FVector2D& Point) const;
 private:
     FVector2D Start;
     FVector2D End;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
@@ -8,7 +8,7 @@
 
 UENUM(BlueprintType)
 enum class EPLATEAURnDir : uint8 {
-    Left UMETA(DisplayName = "XLeft"),
+    Left UMETA(DisplayName = "Left"),
     Right UMETA(DisplayName = "Right"),
 };
 
@@ -17,20 +17,6 @@ UENUM(BlueprintType)
 enum class EPLATEAURnLaneBorderType {
     Prev UMETA(DisplayName = "Prev"),
     Next UMETA(DisplayName = "Next"),
-};
-
-
-USTRUCT()
-struct PLATEAURUNTIME_API FPLATEAURnLaneBorderTypeEx {
-    GENERATED_BODY()
-
-public:
-    /// <summary>
-    /// 反対を取得
-    /// </summary>
-    /// <param name="dir"></param>
-    /// <returns></returns>
-    static EPLATEAURnLaneBorderType GetOpposite(EPLATEAURnLaneBorderType dir);
 };
 
 UENUM(Meta = (Flags))
@@ -74,6 +60,33 @@ public:
     /// <param name="dir"></param>
     /// <returns></returns>
     static EPLATEAURnDir GetOpposite(EPLATEAURnDir dir);
+};
+
+USTRUCT()
+struct PLATEAURUNTIME_API FPLATEAURnLaneBorderDirEx {
+    GENERATED_BODY()
+
+public:
+    /// <summary>
+    /// 反対を取得
+    /// </summary>
+    /// <param name="dir"></param>
+    /// <returns></returns>
+    static EPLATEAURnLaneBorderDir GetOpposite(EPLATEAURnLaneBorderDir dir);
+};
+
+
+USTRUCT()
+struct PLATEAURUNTIME_API FPLATEAURnLaneBorderTypeEx {
+    GENERATED_BODY()
+
+public:
+    /// <summary>
+    /// 反対を取得
+    /// </summary>
+    /// <param name="dir"></param>
+    /// <returns></returns>
+    static EPLATEAURnLaneBorderType GetOpposite(EPLATEAURnLaneBorderType dir);
 };
 
 USTRUCT()

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
@@ -72,7 +72,7 @@ public:
     FLinearColor ReverseWayArrowColor = FLinearColor::Blue;
 
     UPROPERTY(EditAnywhere)
-    float ArrowSize = 0.5f;
+    float ArrowSize = 50.f;
 };
 
 // Add these structures to the header file
@@ -113,6 +113,58 @@ public:
 
     UPROPERTY(EditAnywhere)
     bool bShowPrevRoad = false;
+
+    UPROPERTY(EditAnywhere)
+    bool bShowCenter2Next = false;
+
+};
+
+
+USTRUCT()
+struct FRnModelDrawRoadMergeOption : public FRnModelDrawOption {
+    GENERATED_BODY()
+public:
+    FRnModelDrawRoadMergeOption()
+    {
+        bVisible = false;
+    }
+    UPROPERTY(EditAnywhere)
+    bool bShowMergedBorderNoDir = false;
+
+    UPROPERTY(EditAnywhere)
+    EPLATEAURnDir ShowMergedBorderDir = EPLATEAURnDir::Left;
+
+    UPROPERTY(EditAnywhere)
+    int32 SplitBorderNum = 1;
+};
+USTRUCT()
+struct FRnModelDrawRoadNormalOption : public FRnModelDrawOption {
+    GENERATED_BODY()
+public:
+    UPROPERTY(EditAnywhere)
+    bool bShowSpline = true;
+
+    UPROPERTY(EditAnywhere)
+    int ShowLaneIndex = -1;
+
+    UPROPERTY(EditAnywhere)
+    FLinearColor GroupColor = FLinearColor::Green;
+};
+USTRUCT()
+struct FRnModelDrawRoadGroupOption : public FRnModelDrawOption {
+    GENERATED_BODY()
+public:
+    FRnModelDrawRoadGroupOption() {
+        bVisible = false;
+    }
+    UPROPERTY(EditAnywhere)
+    bool bShowMergedBorderNoDir = false;
+
+    UPROPERTY(EditAnywhere)
+    EPLATEAURnDir ShowMergedBorderDir = EPLATEAURnDir::Left;
+
+    UPROPERTY(EditAnywhere)
+    int32 SplitBorderNum = 1;
 };
 
 USTRUCT()
@@ -121,16 +173,16 @@ struct FRnModelDrawRoadOption : public FRnModelDrawOption {
 public:
 
     UPROPERTY(EditAnywhere)
-    FRnModelDrawLaneOption NormalDrawer;
+    FRnModelDrawRoadMergeOption MergeDrawer;
 
     UPROPERTY(EditAnywhere)
-    bool bShowGroupDrawer = false;
+    FRnModelDrawRoadNormalOption NormalDrawer;
 
     UPROPERTY(EditAnywhere)
-    bool bShowSpline = true;
+    FRnModelDrawRoadGroupOption GroupDrawer;
 
     UPROPERTY(EditAnywhere)
-    FLinearColor GroupColor = FLinearColor::Green;
+    bool bShowGroup = false;
 };
 
 USTRUCT()
@@ -216,9 +268,14 @@ public:
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     FRnModelDrawSideWalkOption SideWalkOption;
 
-    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
-    ERnPartsTypeMask ShowPartsType;
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug", Meta = (Bitmask, BitmaskEnum = ERnPartsTypeMask))
+    int32 ShowPartsType;
 
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    bool bShowOnlyTargets;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    TArray<FString> ShowTargetNames;
 
     void Draw(URnModel* Model);
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnStructureModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnStructureModel.h
@@ -19,7 +19,7 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="PLATEAU")
     FRoadNetworkFactory Factory;
 
-    UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
+    UPROPERTY(VisibleAnywhere, Category = "PLATEAU|Model")
     URnModel* Model;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnStructureModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnStructureModel.h
@@ -20,7 +20,7 @@ public:
     FRoadNetworkFactory Factory;
 
     UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
-    TObjectPtr<URnModel> Model;
+    URnModel* Model;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     FPLATEAURnModelDrawerDebug Debug;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnIntersection.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnIntersection.h
@@ -51,11 +51,11 @@ private:
 
     // 接続先の道路
     UPROPERTY()
-    TObjectPtr<URnRoadBase> Road;
+    URnRoadBase* Road;
 
     // 境界線
     UPROPERTY()
-    TObjectPtr<URnWay> Border;
+    URnWay* Border;
 };
 
 UCLASS()
@@ -163,7 +163,7 @@ private:
 
     // 交差点の外形情報
     UPROPERTY()
-    TArray<TObjectPtr<URnIntersectionEdge>> Edges;
+    TArray<URnIntersectionEdge*> Edges;
 };
 
 struct FRnIntersectionEx

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
@@ -34,7 +34,7 @@ public:
 
     void SetParent(TRnRef_T<URnRoad> InParent);
 
-    [[nodiscard]] bool GetIsReverse() const {
+    bool GetIsReverse() const {
         return bIsReverse;
     }
 
@@ -67,7 +67,7 @@ public:
     bool IsMedianLane() const;
 
     // 境界線の方向を取得する
-    EPLATEAURnLaneBorderDir GetBorderDir(EPLATEAURnLaneBorderType Type) const;
+    TOptional<EPLATEAURnLaneBorderDir> GetBorderDir(EPLATEAURnLaneBorderType Type) const;
 
     // 境界線を取得する
     TRnRef_T<URnWay> GetBorder(EPLATEAURnLaneBorderType Type) const;
@@ -96,9 +96,11 @@ public:
     // 左右のレーンが不正の場合は0を返す
     float CalcMinWidth() const;
 
-
     // 反転する
     void Reverse();
+
+    // Borderの向きをborderDirになるようにそろえる
+    void AlignBorder(EPLATEAURnLaneBorderDir borderDir = EPLATEAURnLaneBorderDir::Left2Right);
 
     // 中心線を生成する
     void BuildCenterWay();
@@ -112,26 +114,13 @@ public:
     // 中心線の長さを取得する
     float GetCenterLength() const;
 
-    // 中心線の2D平面における長さを取得する
-    float GetCenterLength2D(EAxisPlane Plane = FPLATEAURnDef::Plane) const;
-
-    // 中心線の2D平面における角度の合計を取得する
-    float GetCenterTotalAngle2D() const;
-
-    // 中心線の2D平面における曲率を取得する
-    float GetCenterCurvature2D() const;
-
-    // 中心線の2D平面における曲率半径を取得する
-    float GetCenterRadius2D() const;
-
-    // 中心線の2D平面における曲率半径の逆数を取得する
-    float GetCenterInverseRadius2D() const;
-
     // 指定した点からの距離を取得する
     float GetDistanceFrom(const FVector& Point) const;
 
     // 指定した点が車線の内側にあるかどうかを取得する
     bool IsInside(const FVector& Point) const;
+
+    FVector GetCentralVertex() const;
 
     // クローンを作成する
     TRnRef_T<URnLane> Clone() const;
@@ -145,6 +134,11 @@ public:
     /// <param name="centerWay"></param>
     /// <returns></returns>
     static TRnRef_T<URnLane> CreateEmptyLane(TRnRef_T<URnWay> border, TRnRef_T<URnWay> centerWay);
+
+private:
+
+    // typeの境界線をborderDirにそろえる
+    void AlignBorder(EPLATEAURnLaneBorderType type, EPLATEAURnLaneBorderDir borderDir);
 
 private:
     // 親リンク
@@ -175,4 +169,8 @@ private:
     UPROPERTY()
     TObjectPtr<URnWay> CenterWay;
 
+};
+
+struct FRnLaneEx
+{
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
@@ -143,23 +143,23 @@ private:
 private:
     // 親リンク
     UPROPERTY()
-    TWeakObjectPtr<URnRoad> Parent;
+    URnRoad* Parent;
 
     // 境界線(下流)
     UPROPERTY()
-    TObjectPtr<URnWay> PrevBorder;
+    URnWay* PrevBorder;
 
     // 境界線(上流)
     UPROPERTY()
-    TObjectPtr<URnWay> NextBorder;
+    URnWay* NextBorder;
 
     // 車線(左)
     UPROPERTY()
-    TObjectPtr<URnWay> LeftWay;
+    URnWay* LeftWay;
 
     // 車線(右)
     UPROPERTY()
-    TObjectPtr<URnWay> RightWay;
+    URnWay* RightWay;
 
     // 親Roadと逆方向(右車線等)
     UPROPERTY()
@@ -167,7 +167,7 @@ private:
 
     // 内部的に持つだけ. 中心線
     UPROPERTY()
-    TObjectPtr<URnWay> CenterWay;
+    URnWay* CenterWay;
 
 };
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
@@ -67,7 +67,7 @@ public:
     bool IsMedianLane() const;
 
     // 境界線の方向を取得する
-    TOptional<EPLATEAURnLaneBorderDir> GetBorderDir(EPLATEAURnLaneBorderType Type) const;
+    TOptional<EPLATEAURnLaneBorderDir> GetBorderDir(EPLATEAURnLaneBorderType BorderType) const;
 
     // 境界線を取得する
     TRnRef_T<URnWay> GetBorder(EPLATEAURnLaneBorderType Type) const;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLineString.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLineString.h
@@ -87,5 +87,5 @@ public:
 
 private:
     UPROPERTY()
-    TArray<TObjectPtr<URnPoint>> Points;
+    TArray<URnPoint*> Points;
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
@@ -130,6 +130,8 @@ public:
     // roadWidthの道路幅を基準にレーンを分割する
     void SplitLaneByWidth(float RoadWidth, bool rebuildTrack, TArray<FString>& failedRoads);
 
+    // 不正チェック
+    bool Check() const;
 private:
 
     // 自動生成で作成されたときのバージョン

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
@@ -127,6 +127,9 @@ public:
     /// </summary>
     void MergeRoadGroup();
 
+    // roadWidthの道路幅を基準にレーンを分割する
+    void SplitLaneByWidth(float RoadWidth, bool rebuildTrack, TArray<FString>& failedRoads);
+
 private:
 
     // 自動生成で作成されたときのバージョン

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
@@ -139,14 +139,14 @@ private:
 
     // 道路リスト
     UPROPERTY()
-    TArray<TObjectPtr<URnRoad>> Roads;
+    TArray<URnRoad*> Roads;
 
     // 交差点リスト
     UPROPERTY()
-    TArray< TObjectPtr<URnIntersection>> Intersections;
+    TArray<URnIntersection*> Intersections;
 
     // 歩道リスト
     UPROPERTY()
-    TArray< TObjectPtr<URnSideWalk>> SideWalks;
+    TArray<URnSideWalk*> SideWalks;
 
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Component/PLATEAUSceneComponent.h"
 #include "RoadNetwork/PLATEAURnDef.h"
 #include "RnModel.generated.h"
 class URnRoad;
@@ -29,7 +30,7 @@ public:
 };
 
 UCLASS()
-class URnModel : public UObject
+class URnModel : public UPLATEAUSceneComponent
 {
 public:
     const FString& GetFactoryVersion() const;
@@ -45,7 +46,7 @@ public:
 
     URnModel();
 
-    void Init(){}
+    void Init();
 
     // 道路を追加
     void AddRoadBase(const TRnRef_T<URnRoadBase>& RoadBase);
@@ -138,15 +139,15 @@ private:
     FString FactoryVersion;
 
     // 道路リスト
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
     TArray<URnRoad*> Roads;
 
     // 交差点リスト
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
     TArray<URnIntersection*> Intersections;
 
     // 歩道リスト
-    UPROPERTY()
+    UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
     TArray<URnSideWalk*> SideWalks;
 
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -110,10 +110,10 @@ public:
     void AddMainLane(TRnRef_T<URnLane> Lane);
 
 
-    // 指定した方向の境界線を取得する
+    // 指定した方向の境界線を取得する(全レーンマージした状態で取得する)
     virtual TRnRef_T<URnWay> GetMergedBorder(EPLATEAURnLaneBorderType BorderType, std::optional<EPLATEAURnDir> Dir) const override;
 
-    // 指定した方向のWayを取得する
+    // 指定した方向のWayを取得する(全レーンマージした状態で取得する)
     virtual TRnRef_T<URnWay> GetMergedSideWay(EPLATEAURnDir Dir) const override;
 
     // dirで指定した側の全レーンの左右のWayを返す

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -195,19 +195,19 @@ private:
 public:
     // 接続先(nullの場合は接続なし)
     UPROPERTY()
-    TWeakObjectPtr<URnRoadBase> Next;
+    URnRoadBase* Next;
 
     // 接続元(nullの場合は接続なし)
     UPROPERTY()
-    TWeakObjectPtr<URnRoadBase> Prev;
+    URnRoadBase* Prev;
 
     // レーンリスト
     UPROPERTY()
-    TArray<TObjectPtr<URnLane>> MainLanes;
+    TArray<URnLane*> MainLanes;
 
     // 中央分離帯
     UPROPERTY()
-    TObjectPtr<URnLane> MedianLane;
+    URnLane* MedianLane;
 
 };
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -62,6 +62,9 @@ public:
     // 指定方向のレーンを取得
     TArray<TRnRef_T<URnLane>> GetLanes(EPLATEAURnDir Dir) const;
 
+    // 指定方向のレーンを取得. Dirが指定されていない場合はMainLanes全体を返す
+    bool TryGetLanes(TOptional<EPLATEAURnDir> Dir, TArray<TRnRef_T<URnLane>>& OutLanes) const;
+
     // レーンが左車線かどうか
     bool IsLeftLane(const TRnRef_T<URnLane>& Lane) const;
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -50,12 +50,13 @@ public:
 
     void SetPrev(TRnRef_T<URnRoadBase> InPrev);
 
-
     void SetMedianLane1(TRnRef_T<URnLane> InMedianLane);
 
     TRnRef_T<URnRoadBase> GetNext() const;
 
     TRnRef_T<URnRoadBase> GetPrev() const;
+
+    TRnRef_T<URnRoadBase> GetNeighborRoad(EPLATEAURnLaneBorderType BorderType) const;
 
     TRnRef_T<URnLane> GetMedianLane() const;
 
@@ -111,27 +112,27 @@ public:
 
 
     // 指定した方向の境界線を取得する(全レーンマージした状態で取得する)
-    virtual TRnRef_T<URnWay> GetMergedBorder(EPLATEAURnLaneBorderType BorderType, std::optional<EPLATEAURnDir> Dir) const override;
+    TRnRef_T<URnWay> GetMergedBorder(EPLATEAURnLaneBorderType BorderType, TOptional<EPLATEAURnDir> Dir) const;
 
     // 指定した方向のWayを取得する(全レーンマージした状態で取得する)
-    virtual TRnRef_T<URnWay> GetMergedSideWay(EPLATEAURnDir Dir) const override;
+    TRnRef_T<URnWay> GetMergedSideWay(EPLATEAURnDir Dir) const;
 
     // dirで指定した側の全レーンの左右のWayを返す
     // dir==nullの時は全レーン共通で返す
     // 例) 左２車線でdir==RnDir.Leftの場合, 一番左の車線の左側のWayと左から２番目の車線の右側のWayを返す
-    bool TryGetMergedSideWay(std::optional<EPLATEAURnDir> Dir, TRnRef_T<URnWay>& OutLeftWay, TRnRef_T<URnWay>& OutRightWay) const;
+    bool TryGetMergedSideWay(TOptional<EPLATEAURnDir> Dir, TRnRef_T<URnWay>& OutLeftWay, TRnRef_T<URnWay>& OutRightWay) const;
 
     // 指定したLineStringまでの最短距離を取得する
-    virtual bool TryGetNearestDistanceToSideWays(const TRnRef_T<URnLineString>& LineString, float& OutDistance) const override;
+    bool TryGetNearestDistanceToSideWays(const TRnRef_T<URnLineString>& LineString, float& OutDistance) const;
 
     // 境界線の向きをそろえる
-    virtual void AlignLaneBorder() override;
+    void AlignLaneBorder(EPLATEAURnLaneBorderDir BorderDir = EPLATEAURnLaneBorderDir::Left2Right);
 
     // 境界線を調整するための線分を取得する
-    virtual bool TryGetAdjustBorderSegment(EPLATEAURnLaneBorderType BorderType, FLineSegment3D& OutSegment) const override;
+    bool TryGetAdjustBorderSegment(EPLATEAURnLaneBorderType BorderType, FLineSegment3D& OutSegment) const;
 
     // 指定したレーンの境界線を取得する
-    virtual TRnRef_T<URnWay> GetBorderWay(const TRnRef_T<URnLane>& Lane, EPLATEAURnLaneBorderType BorderType, EPLATEAURnLaneBorderDir Dir) const override;
+    virtual TRnRef_T<URnWay> GetBorderWay(const TRnRef_T<URnLane>& Lane, EPLATEAURnLaneBorderType BorderType, EPLATEAURnLaneBorderDir BorderDir) const;
 
     // レーンを置き換える
     void ReplaceLanes(const TArray<TRnRef_T<URnLane>>& NewLanes, EPLATEAURnDir Dir);
@@ -141,7 +142,10 @@ public:
     void SetPrevNext(const TRnRef_T<URnRoadBase>& PrevRoad, const TRnRef_T<URnRoadBase>& NextRoad);
 
     // 反転する
-    void Reverse();
+    // Next,Prevを逆転する.
+    // その結果, レーンのIsReverseも逆転 / mainLanesの配列順も逆転する
+    // keepOneLaneIsLeftがtrueの場合, 1車線しか無い道路だとその1車線がRoadのPrev / Nextを同じ方向になるように(左車線扱い)する
+    void Reverse(bool KeepOneLaneIsLeft = true);
 
     // デバッグ用) その道路の中心を表す代表頂点を返す
     virtual FVector GetCentralVertex() const override;
@@ -173,6 +177,8 @@ public:
         return TRnRef_T<URnIntersection>(nullptr);
     }
 
+    // 構造的に正しいかどうかチェック
+    virtual bool Check() const override;
     // 道路を作成する
     static TRnRef_T<URnRoad> Create(TObjectPtr<UPLATEAUCityObjectGroup> TargetTran = nullptr);
     static TRnRef_T<URnRoad> Create(const TArray<TObjectPtr<UPLATEAUCityObjectGroup>>& TargetTrans);
@@ -203,4 +209,11 @@ public:
     UPROPERTY()
     TObjectPtr<URnLane> MedianLane;
 
+};
+
+struct FRnRoadEx
+{
+
+    static auto IsValidBorderAdjacentNeighbor(const URnRoad* Self, EPLATEAURnLaneBorderType BorderType,
+                                              bool NoBorderIsTrue) -> bool;
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
@@ -99,7 +99,7 @@ private:
 
     // 自分が所属するRoadNetworkModel
     UPROPERTY()
-    TObjectPtr<URnModel> ParentModel;
+    URnModel* ParentModel;
 
     // これに紐づくtranオブジェクトリスト(統合なので複数存在する場合がある)
     UPROPERTY()
@@ -107,6 +107,6 @@ private:
 
     // 歩道情報
     UPROPERTY()
-    TArray<TObjectPtr<URnSideWalk>> SideWalks;
+    TArray<URnSideWalk*> SideWalks;
 
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
@@ -77,29 +77,11 @@ public:
     TRnRef_T<URnModel> GetParentModel() const;
     void SetParentModel(const TRnRef_T<URnModel>& InParentModel);
 
-    // 指定した方向の境界線を取得する
-    virtual TRnRef_T<URnWay> GetMergedBorder(EPLATEAURnLaneBorderType BorderType, std::optional<EPLATEAURnDir> Dir) const { return nullptr; }
-
-    // 指定した方向のWayを取得する
-    virtual TRnRef_T<URnWay> GetMergedSideWay(EPLATEAURnDir Dir) const { return nullptr; }
-
-    // 指定した方向のWayを取得する
-    virtual bool TryGetMergedSideWay(EPLATEAURnDir Dir, TRnRef_T<URnWay>& OutLeftWay, TRnRef_T<URnWay>& OutRightWay) const { return false; }
-
-    // 指定したLineStringまでの最短距離を取得する
-    virtual bool TryGetNearestDistanceToSideWays(const TRnRef_T<URnLineString>& LineString, float& OutDistance) const { return false; }
-
-    // 境界線の向きをそろえる
-    virtual void AlignLaneBorder() {}
-
-    // 境界線を調整するための線分を取得する
-    virtual bool TryGetAdjustBorderSegment(EPLATEAURnLaneBorderType BorderType, FLineSegment3D& OutSegment) const { return false; }
-
-    // 指定したレーンの境界線を取得する
-    virtual TRnRef_T<URnWay> GetBorderWay(const TRnRef_T<URnLane>& Lane, EPLATEAURnLaneBorderType BorderType, EPLATEAURnLaneBorderDir Dir) const { return nullptr; }
-
-    // 指定したレーンの境界線を取得する
-    virtual TRnRef_T<URnWay> GetBorderWay(const TRnRef_T<URnLane>& Lane, EPLATEAURnLaneBorderType BorderType) const { return nullptr; }
+    // 構造的に正しいかどうかチェック
+    virtual bool Check() const
+    {
+        return true;
+    }
 
     // RnRoadへキャストする
     virtual TRnRef_T<URnRoad> CastToRoad()

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadGroup.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadGroup.h
@@ -127,8 +127,7 @@ private:
     TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>> SplitLane(
         int32 Num,
         TOptional<EPLATEAURnDir> Dir,
-        // #TODO : nullptr入れられるのか確認
-        TFunction<float(int32)> GetSplitRate = nullptr);
+        const TFunction<float(int32)>& GetSplitRate = nullptr);
 
     // レーン分割する
     void SetLaneCountImpl(int32 Count, EPLATEAURnDir Dir, bool RebuildTrack);

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadGroup.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadGroup.h
@@ -31,6 +31,9 @@ public:
     // 有効なRoadGroupかどうか
     bool IsValid() const;
 
+    // 全レーンが有効かどうか
+    bool IsAllLaneValid() const;
+
     // 左側のレーン数を取得
     int32 GetLeftLaneCount() const;
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadGroup.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadGroup.h
@@ -126,7 +126,7 @@ private:
 
     TMap<TRnRef_T<URnRoad>, TArray<TRnRef_T<URnLane>>> SplitLane(
         int32 Num,
-        std::optional<EPLATEAURnDir> Dir,
+        TOptional<EPLATEAURnDir> Dir,
         // #TODO : nullptr入れられるのか確認
         TFunction<float(int32)> GetSplitRate = nullptr);
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
@@ -94,13 +94,13 @@ private:
     TWeakObjectPtr<URnRoadBase> ParentRoad;
 
     UPROPERTY()
-    TObjectPtr<URnWay> OutsideWay;
+    URnWay* OutsideWay;
     UPROPERTY()
-    TObjectPtr<URnWay> InsideWay;
+    URnWay* InsideWay;
     UPROPERTY()
-    TObjectPtr<URnWay> StartEdgeWay;
+    URnWay* StartEdgeWay;
     UPROPERTY()
-    TObjectPtr<URnWay> EndEdgeWay;
+    URnWay* EndEdgeWay;
     UPROPERTY()
     EPLATEAURnSideWalkLaneType LaneType;
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
@@ -85,6 +85,10 @@ public:
     // 近接スコア計算
     float CalcRoadProximityScore(const TRnRef_T<URnRoadBase>& Other) const;
 
+    bool Check() const
+    {
+        return true;
+    }
 private:
     UPROPERTY()
     TWeakObjectPtr<URnRoadBase> ParentRoad;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnWay.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnWay.h
@@ -189,7 +189,7 @@ public:
     bool IsReverseNormal;
 
     UPROPERTY()
-    TObjectPtr<URnLineString> LineString;
+    URnLineString* LineString;
 };
 
 struct FRnWayEx

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnWay.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnWay.h
@@ -54,7 +54,7 @@ public:
         }
 
         PointIterator end() const {
-            return PointIterator(Way, Way->Count());
+            return PointIterator(Way,  Way ?Way->Count() : 0);
         }
 
         const URnWay* Way;
@@ -93,13 +93,15 @@ public:
         }
 
         VertexIterator end() const {
-            return VertexIterator(Way, Way->Count());
+            return VertexIterator(Way,  Way ?Way->Count() : 0);
         }
 
         TArray<FVector> ToArray() const {
             TArray<FVector> Result;
-            for (int32 i = 0; i < Way->Count(); ++i) {
-                Result.Add(Way->GetVertex(i));
+            if (Way) {
+                for (int32 i = 0; i < Way->Count(); ++i) {
+                    Result.Add(Way->GetVertex(i));
+                }
             }
             return Result;
         }

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnDebugEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnDebugEx.h
@@ -22,16 +22,16 @@ public:
     static FVector ToVec3(const FVector2D& Self, bool bShowXZ);
     static FLinearColor GetDebugColor(int32 I, int32 Num = 8, float A = 1.0f);
     static void DrawLine(const FVector& Start, const FVector& End, const FLinearColor& Color = FLinearColor::White, float Duration = 0.0f, float Thickness = 0.0f);
-    static void DrawArrow(const FVector& Start, const FVector& End, float ArrowSize = 0.5f, const FVector& ArrowUp = FVector::UpVector, const FLinearColor& BodyColor = FLinearColor::White, const FLinearColor& ArrowColor = FLinearColor::White, float Duration = 0.0f, float Thickness = 0.0f);
-    static void DrawArrows(const TArray<FVector>& Vertices, bool bIsLoop = false, float ArrowSize = 0.5f, const FVector& ArrowUp = FVector::UpVector, const FLinearColor& Color = FLinearColor::White, const FLinearColor& ArrowColor = FLinearColor::White, float Duration = 0.0f, float Thickness = 0.0f);
+    static void DrawArrow(const FVector& Start, const FVector& End, float ArrowSize = 50.f, const FVector& ArrowUp = FVector::UpVector, const FLinearColor& BodyColor = FLinearColor::White, const FLinearColor& ArrowColor = FLinearColor::White, float Duration = 0.0f, float Thickness = 0.0f);
+    static void DrawArrows(const TArray<FVector>& Vertices, bool bIsLoop = false, float ArrowSize = 50.f, const FVector& ArrowUp = FVector::UpVector, const FLinearColor& Color = FLinearColor::White, const FLinearColor& ArrowColor = FLinearColor::White, float Duration = 0.0f, float Thickness = 0.0f);
     static void DrawLines(const TArray<FVector>& Vertices, bool bIsLoop = false, const FLinearColor& Color = FLinearColor::White, float Duration = 0.0f, float Thickness = 0.0f);
     static void DrawSphere(const FVector& Center, float Radius, const FLinearColor& Color = FLinearColor::White, float Duration = 0.0f);
     static void DrawRegularPolygon(const FVector& Center, float Radius, int32 Sides = 5, const FVector& Up = FVector::UpVector, const FLinearColor& Color = FLinearColor::White, float Duration = 0.0f);
-    static void DrawDashedLine(const FVector& Start, const FVector& End, const FLinearColor& Color = FLinearColor::White, float LineLength = 1.0f, float SpaceLength = 0.2f, float Duration = 0.0f);
+    static void DrawDashedLine(const FVector& Start, const FVector& End, const FLinearColor& Color = FLinearColor::White, float LineLength = 100.0f, float SpaceLength = 20.f, float Duration = 0.0f);
 
-    static void DrawDashedArrow(const FVector& Start, const FVector& End, const FLinearColor& Color = FLinearColor::White, float LineLength = 1.0f, float SpaceLength = 0.2f, float Duration = 0.0f, float ArrowSize = 0.5f, const FVector& ArrowUp = FVector::UpVector);
-    static void DrawDashedLines(const TArray<FVector>& Vertices, bool bIsLoop = false, const FLinearColor& Color = FLinearColor::White, float LineLength = 3.0f, float SpaceLength = 1.0f, float Duration = 0.0f);
-    static void DrawDashedArrows(const TArray<FVector>& Vertices, bool bIsLoop = false, const FLinearColor& Color = FLinearColor::White, float LineLength = 3.0f, float SpaceLength = 1.0f, float Duration = 0.0f);
+    static void DrawDashedArrow(const FVector& Start, const FVector& End, const FLinearColor& Color = FLinearColor::White, float LineLength = 100.0, float SpaceLength = 20.f, float Duration = 0.0f, float ArrowSize = 0.5f, const FVector& ArrowUp = FVector::UpVector);
+    static void DrawDashedLines(const TArray<FVector>& Vertices, bool bIsLoop = false, const FLinearColor& Color = FLinearColor::White, float LineLength = 300.0f, float SpaceLength = 100.0f, float Duration = 0.0f);
+    static void DrawDashedArrows(const TArray<FVector>& Vertices, bool bIsLoop = false, const FLinearColor& Color = FLinearColor::White, float LineLength = 300.0f, float SpaceLength = 100.0f, float Duration = 0.0f);
     static void DrawRay(const FVector& Start, const FVector& Direction, const FLinearColor& Color = FLinearColor::White, float Duration = 0.0f);
     static void DrawString(const FString& Text, const FVector& Location,  const FLinearColor& Color = FLinearColor::White, float Duration = 0.0f, float FontScale = 1.f);
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnEx.h
@@ -59,49 +59,7 @@ public:
         const FLineSegment3D& LineSegment,
         const TArray<TRnRef_T<URnWay>>& Ways);
 
-
-    template<typename T, typename U>
-    static TArray<U> Map(const TArray<T>& Src, TFunction< U(const T&)> Selector)
-    {
-        TArray<U> Result;
-        Result.Reserve(Src.Num());
-        for (const auto& S : Src) {
-            Result.Add(Selector(S));
-        }
-        return Result;
-    }
-
-private:
-    template<typename T>
-    static bool TryFirstOrDefaultImpl(const TSet<T>& Set, TFunction<bool(const T&)> Predicate, T& OutV) {
-        for (auto& S : Set) {
-            if (Predicate(S)) {
-                OutV = S;
-                return true;
-            }
-        }
-        return false;
-    }
 public:
-    template<typename T, typename F>
-    static bool TryFirstOrDefault(const TSet<T>& Set, F&& Predicate, T& OutV) {
-        return TryFirstOrDefaultImpl<T>(Set, Predicate, OutV);
-    }
-
-    template<typename T, typename F>
-    static auto SelectWithIndex(T&& Src, F&& Selector)
-    {
-        using U = decltype(Selector(Src[0], 0));
-        TArray<U> Result;
-        auto Index = 0;
-        for (auto&& E : Src) 
-        {
-            Result.Add(Selector(E, Index));
-            Index++;
-        }
-        return Result;
-    }
-
     template<typename T>
     static int32 Compare(T A, T B)
     {
@@ -111,8 +69,6 @@ public:
             return 1;
         return 0;
     }
-
-
 
 
     // ParentにChildを追加する

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnLinq.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnLinq.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "RoadNetwork/PLATEAURnDef.h"
+#include <optional>
+
+#include "RoadNetwork/GeoGraph/LineSegment3D.h"
+#include "RoadNetwork/RGraph/RGraphDef.h"
+
+class UPLATEAUCityObjectGroup;
+class URnIntersection;
+class URnLineString;
+class URnWay;
+class URnPoint;
+class URnLane;
+
+struct FPLATEAURnLinq
+{
+private:
+    template<typename TSrc, typename TDst>
+    static auto SelectImpl(const TArray<TSrc>& Src, TFunction<TDst(const TSrc&)> Selector)
+    {
+        TArray<TDst> Result;
+        Result.Reserve(Src.Num());
+        for (const auto& S : Src) {
+            Result.Add(Selector(S));
+        }
+        return Result;
+    }
+    template<typename TSrc, typename TDst>
+    static auto SelectWithIndexImpl(const TArray<TSrc>& Src, TFunction<TDst(const TSrc&, int32 Index)> Selector) {
+        TArray<TDst> Result;
+        Result.Reserve(Src.Num());
+        auto Index = 0;
+        for (auto&& E : Src) {
+            Result.Add(Selector(E, Index));
+            Index++;
+        }
+        return Result;
+    }
+public:
+    // Linq.Select代わり
+    // Src      : 範囲forで回せるコンテナ
+    // Selector : Srcの要素を受け取り、変換した値を返す関数
+    template<typename T, typename F>
+    static auto Select(const TArray<T>& Src, F&& Selector)
+    {
+        using DstType = decltype(Selector(*Src.begin()));
+        return SelectImpl<T, DstType>(Src, Forward<F>(Selector));
+    }
+
+    // Linq.Select代わり(index渡すバージョン)
+    // Src      : 範囲forで回せるコンテナ
+    // Selector : Srcの要素とインデックスを受け取り、変換した値を返す関数
+    template<typename T, typename F>
+    static auto SelectWithIndex(const TArray<T>& Src, F&& Selector) {
+
+        using DstType = decltype(Selector(*Src.begin()));
+        return SelectWithIndexImpl<T, DstType>(Src, Forward<F>(Selector));
+    }
+
+private:
+    template<typename T>
+    static bool TryFirstOrDefaultImpl(const TSet<T>& Set, TFunction<bool(const T&)> Predicate, T& OutV) {
+        for (auto& S : Set) {
+            if (Predicate(S)) {
+                OutV = S;
+                return true;
+            }
+        }
+        return false;
+    }
+public:
+    template<typename T, typename F>
+    static bool TryFirstOrDefault(const TSet<T>& Set, F&& Predicate, T& OutV);
+};
+
+template <typename T, typename F>
+bool FPLATEAURnLinq::TryFirstOrDefault(const TSet<T>& Set, F&& Predicate, T& OutV)
+{
+    return TryFirstOrDefaultImpl<T>(Set, Predicate, OutV);
+}

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAUVector2DEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAUVector2DEx.h
@@ -26,6 +26,10 @@ public:
     // Cross product of 2D vectors
     static float Cross(const FVector2D& A, const FVector2D& B);
 
+    // ToがFromの左側にあるかどうか
+    // 原点(O)に対してO -> Fromの方向ベクトルと, O -> Toの方向ベクトルの外積でチェック
+    static bool IsPointOnLeftSide(const FVector2D& From, const FVector2D& To);
+
     // Rotate vector towards target with max angle
     static FVector2D RotateTo(const FVector2D& From, const FVector2D& To, float MaxRad);
 


### PR DESCRIPTION
## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-258

## 実装内容
道路幅に応じてレーンを分割する処理をC#から移植

## 動作確認
道路構造を生成し, プレイボタンを押す
![image](https://github.com/user-attachments/assets/32e46f2d-ed33-487f-99ab-0d1abd318f6e)

アウトライナでPLATEAURnStructureModelを選んで以下の項目がオンになっていれば、分割されたレーンが表示されるかと
![image](https://github.com/user-attachments/assets/7b64df7d-7ffe-44a9-9ddc-bba686efe477)


## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [x] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
