### PR TITLE
マテリアル分け機能で、指定外のマテリアルが剥がれたりする問題を修正

### DIFF
--- a/Source/PLATEAURuntime/Private/PLATEAUInstancedCityModel.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUInstancedCityModel.cpp
@@ -150,7 +150,7 @@ bool APLATEAUInstancedCityModel::HasAttributeInfo() {
         });
 }
 
-TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ReconstructModel(const TArray<USceneComponent*> TargetComponents, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal)  {
+TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ReconstructModel(const TArray<USceneComponent*>& TargetComponents, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal)  {
 
     UE_LOG(LogTemp, Log, TEXT("ReconstructModel: %d %d %s"), TargetComponents.Num(), static_cast<int>(ReconstructType), bDestroyOriginal ? TEXT("True") : TEXT("False"));
     TTask<TArray<USceneComponent*>> ReconstructModelTask = Launch(TEXT("ReconstructModelTask"), [this, TargetComponents, ReconstructType, bDestroyOriginal] {       
@@ -169,7 +169,7 @@ TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ReconstructModel(con
     return ReconstructModelTask;
 }
 
-TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyModel(const TArray<USceneComponent*> TargetComponents, TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal) {
+TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyModel(const TArray<USceneComponent*>& TargetComponents, TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal) {
     
     UE_LOG(LogTemp, Log, TEXT("ClassifyModelByType: %d %d %s"), TargetComponents.Num(), static_cast<int>(ReconstructType), bDestroyOriginal ? TEXT("True") : TEXT("False"));
     TTask<TArray<USceneComponent*>> ClassifyModelByTypeTask = Launch(TEXT("ClassifyModelByTypeTask"), [&, this, TargetComponents, bDestroyOriginal, Materials, ReconstructType] {
@@ -190,7 +190,7 @@ TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyModel(const 
     return ClassifyModelByTypeTask;
 }
 
-UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyModel(const TArray<USceneComponent*> TargetComponents, const FString AttributeKey, TMap<FString, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal) {
+UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyModel(const TArray<USceneComponent*>& TargetComponents, const FString& AttributeKey, TMap<FString, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal) {
     
     UE_LOG(LogTemp, Log, TEXT("ClassifyModelByAttr: %d %d %s"), TargetComponents.Num(), static_cast<int>(ReconstructType), bDestroyOriginal ? TEXT("True") : TEXT("False"));
     TTask<TArray<USceneComponent*>> ClassifyModelByAttrTask = Launch(TEXT("ClassifyModelByAttrTask"), [&, this, TargetComponents, AttributeKey, bDestroyOriginal, Materials, ReconstructType] {
@@ -211,7 +211,7 @@ UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyM
     return ClassifyModelByAttrTask;
 }
 
-UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyTask(FPLATEAUModelClassification& ModelClassification, const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal) {
+UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyTask(FPLATEAUModelClassification& ModelClassification, const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal) {
 
     TTask<TArray<USceneComponent*>> ClassifyTask = Launch(TEXT("ClassifyTask"), [&, TargetCityObjects, ReconstructType, bDestroyOriginal] {
 
@@ -219,7 +219,7 @@ UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyT
 
             //粒度ごとにターゲットを取得して実行
             TArray<USceneComponent*> JoinedResults;
-            TArray<ConvertGranularity> GranularityList{ 
+            const TArray<ConvertGranularity> GranularityList{
                 ConvertGranularity::PerAtomicFeatureObject,
                 ConvertGranularity::PerPrimaryFeatureObject,
                 ConvertGranularity::PerCityModelArea,
@@ -250,7 +250,7 @@ UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ClassifyT
 }
 
 
-UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ReconstructTask(FPLATEAUModelReconstruct& ModelReconstruct, const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects, bool bDestroyOriginal) {
+UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::ReconstructTask(FPLATEAUModelReconstruct& ModelReconstruct, const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects, bool bDestroyOriginal) {
 
     TTask<TArray<USceneComponent*>> ConvertTask = Launch(TEXT("ReconstructTask"), [&, TargetCityObjects, bDestroyOriginal] {
         std::shared_ptr<plateau::polygonMesh::Model> converted = ModelReconstruct.ConvertModelForReconstruct(TargetCityObjects);
@@ -267,7 +267,7 @@ UE::Tasks::TTask<TArray<USceneComponent*>> APLATEAUInstancedCityModel::Reconstru
 }
 
 //Landscape
-UE::Tasks::FTask APLATEAUInstancedCityModel::CreateLandscape(const TArray<USceneComponent*> TargetComponents, FPLATEAULandscapeParam Param, bool bDestroyOriginal) {
+UE::Tasks::FTask APLATEAUInstancedCityModel::CreateLandscape(const TArray<USceneComponent*>& TargetComponents, FPLATEAULandscapeParam Param, bool bDestroyOriginal) {
 
     UE_LOG(LogTemp, Log, TEXT("CreateLandscape: %d %s"), TargetComponents.Num(), bDestroyOriginal ? TEXT("True") : TEXT("False"));
     FTask CreateLandscapeTask = Launch(TEXT("CreateLandscapeTask"), [&, TargetComponents, Param, bDestroyOriginal] {
@@ -333,7 +333,7 @@ UE::Tasks::FTask APLATEAUInstancedCityModel::CreateLandscape(const TArray<UScene
     return CreateLandscapeTask;
 }
 
-TArray<UPLATEAUCityObjectGroup*> APLATEAUInstancedCityModel::AlignLand(TArray<HeightmapCreationResult>& Results, FPLATEAULandscapeParam Param, bool bDestroyOriginal) {
+TArray<UPLATEAUCityObjectGroup*> APLATEAUInstancedCityModel::AlignLand(TArray<HeightmapCreationResult>& Results, const FPLATEAULandscapeParam& Param, bool bDestroyOriginal) {
 
     FPLATEAUModelAlignLand ModelAlign(this);
     ModelAlign.SetResults(Results, Param);

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
@@ -447,12 +447,11 @@ UStaticMeshComponent* FPLATEAUMeshLoader::CreateStaticMeshComponent(AActor& Acto
                         }
 
                         MaterialInterface = GetMaterialForSubMesh(SubMeshValue, Component, LoadInputData, Texture, NodeHier);
-                        UMaterialInstanceDynamic* DynMaterial = StaticCast<UMaterialInstanceDynamic*>(MaterialInterface);
-                        if (DynMaterial) {
+                        if (auto DynMaterial = Cast<UMaterialInstanceDynamic>(MaterialInterface)) {
                             //Textureが存在する場合
                             if (Texture != nullptr)
                                 DynMaterial->SetTextureParameterValue("Texture", Cast<UTexture>(Texture));
-
+                        
                             DynMaterial->TwoSided = false;
                         }
                         

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUMeshLoaderForClassification.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUMeshLoaderForClassification.cpp
@@ -1,16 +1,18 @@
 // Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 #include "Reconstruct/PLATEAUMeshLoaderForClassification.h"
+
+#include "PLATEAUCachedMaterialArray.h"
 #include "PLATEAUMeshLoader.h"
 #include "Component/PLATEAUCityObjectGroup.h"
 
-FPLATEAUMeshLoaderForClassification::FPLATEAUMeshLoaderForClassification(const TMap<int, UMaterialInterface*> Materials) {
-    ClassificationMaterials = Materials;
+FPLATEAUMeshLoaderForClassification::FPLATEAUMeshLoaderForClassification(FPLATEAUCachedMaterialArray Mats) {
+    CachedMaterials = Mats;
     bAutomationTest = false;
 }
 
-FPLATEAUMeshLoaderForClassification::FPLATEAUMeshLoaderForClassification(const TMap<int, UMaterialInterface*> Materials, const bool InbAutomationTest) {
-    ClassificationMaterials = Materials;
+FPLATEAUMeshLoaderForClassification::FPLATEAUMeshLoaderForClassification(FPLATEAUCachedMaterialArray Mats, const bool InbAutomationTest) {
+    CachedMaterials = Mats;
     bAutomationTest = InbAutomationTest;
 }
 
@@ -19,15 +21,21 @@ UMaterialInterface* FPLATEAUMeshLoaderForClassification::GetMaterialForSubMesh(c
 
     UE_LOG(LogTemp, Log, TEXT("GetMaterialForSubMesh: %d"), SubMeshValue.GameMaterialID);
 
-    if (SubMeshValue.GameMaterialID > -1 && !ClassificationMaterials.IsEmpty() && ClassificationMaterials.Contains(SubMeshValue.GameMaterialID)) {
-        const auto& MatPtr = ClassificationMaterials.Find(SubMeshValue.GameMaterialID);
+    if (SubMeshValue.GameMaterialID > -1 && CachedMaterials.Num() > 0 && SubMeshValue.GameMaterialID < CachedMaterials.Num()) {
+        const auto MatPtr = CachedMaterials.Get(SubMeshValue.GameMaterialID);
         if (MatPtr != nullptr) {
-            const auto& Mat = *MatPtr;
+            const auto& Mat = MatPtr;
             if (Mat != nullptr)
-                return UMaterialInstanceDynamic::Create(Mat, Component);
+            {
+                // ここで UMaterialInstanceDynamic::Create(Mat, Component); としてはいけません。
+                // なぜなら、マテリアル分けを複数回実行したときに、キー指定対象外の部分でマテリアルが剥がれるためです。
+                return Mat;
+            }
+                
         }    
     }
     return FPLATEAUMeshLoader::GetMaterialForSubMesh(SubMeshValue, Component, LoadInputData, Texture, NodeHier);
 }
+
 
 

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByAttribute.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByAttribute.cpp
@@ -21,40 +21,38 @@ namespace {
     }
 }
 
-FPLATEAUModelClassificationByAttribute::FPLATEAUModelClassificationByAttribute() {}
 
-FPLATEAUModelClassificationByAttribute::FPLATEAUModelClassificationByAttribute(APLATEAUInstancedCityModel* Actor, const FString AttributeKey, const TMap<FString, UMaterialInterface*> Materials)
+FPLATEAUModelClassificationByAttribute::FPLATEAUModelClassificationByAttribute(APLATEAUInstancedCityModel* Actor, const FString& AttributeKey, const TMap<FString, UMaterialInterface*>& Materials)
 {
     CityModelActor = Actor;
     ClassificationAttributeKey = AttributeKey;
     ClassificationMaterials = Materials;
     bDivideGrid = false;
-
-    //マテリアルごとにMaterial ID生成
-    TMap<UMaterialInterface*, int> Material_MaterialIDMap;
-    int ID = 0;
-    for (const auto& KV : ClassificationMaterials) { //同一Materialを共通Material IDに
-        if (!Material_MaterialIDMap.Contains(KV.Value)) {
-            Material_MaterialIDMap.Add(KV.Value, ID);
-            ID++;
-        }
-    }
-    //属性の値ごとにMaterial IDをセット
-    for (const auto& KV : ClassificationMaterials) {
-        MaterialIDMap.Add(KV.Key, Material_MaterialIDMap[KV.Value]);
-    }
 }
 
 void FPLATEAUModelClassificationByAttribute::SetConvertGranularity(const ConvertGranularity Granularity) {
     ConvGranularity = Granularity;
 }
 
-std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByAttribute::ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects) {
+std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByAttribute::ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects) {
 
     //最小地物単位のModelを生成
     std::shared_ptr<plateau::polygonMesh::Model> converted = ConvertModelWithGranularity(TargetCityObjects, ConvertGranularity::PerAtomicFeatureObject);
 
     plateau::materialAdjust::MaterialAdjusterByAttr Adjuster;
+
+    // CachedMaterialに元々のマテリアルを追加
+    ComposeCachedMaterialFromTarget(TargetCityObjects);
+    
+    // ChachedMaterialに入っている元々のマテリアルに追加で、マテリアル分け用のマテリアルを追加
+    TMap<int, UMaterialInterface*> ClassifyMatIDs;
+    for(const auto& [Attr, Mat] : ClassificationMaterials)
+    {
+        int id = CachedMaterials.Add(Mat);
+            Adjuster.registerMaterialPattern(TCHAR_TO_UTF8(*Attr), id);
+    }
+
+    
     auto meshes = converted.get()->getAllMeshes();
     for (auto& mesh : meshes) {
         auto cityObjList = mesh->getCityObjectList();
@@ -68,13 +66,9 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByAttrib
                 TSet<FString> AttributeStringValues = ConvertAttributeValuesToUniqueStringValues(AttributeValues);
                 
                 for (const auto& Value : AttributeStringValues) {
-                    if (MaterialIDMap.Contains(Value)) {
-                        int MaterialID = MaterialIDMap[Value];
+                    if (ClassificationMaterials.Contains(Value)) {
 
                         Adjuster.registerAttribute(GmlId, TCHAR_TO_UTF8(*Value));
-                        Adjuster.registerMaterialPattern(TCHAR_TO_UTF8(*Value), MaterialID);
-
-                        UE_LOG(LogTemp, Log, TEXT("Register Mat: %s %s %d"), *FString(GmlId.c_str()), *Value, MaterialID);
 
                         const auto AttrInfo = *AttrInfoPtr;
                         TSet<FString> Children = FPLATEAUGmlUtil::GetChildrenGmlIds(AttrInfo);
@@ -97,13 +91,6 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByAttrib
 
 TArray<USceneComponent*> FPLATEAUModelClassificationByAttribute::ReconstructFromConvertedModel(std::shared_ptr<plateau::polygonMesh::Model> Model) {
 
-    TMap<int, UMaterialInterface*> NewClassificationMaterials;
-    for (const auto& KV : ClassificationMaterials) {
-        const int* MaterialID = MaterialIDMap.Find(KV.Key);
-        if(MaterialID != nullptr && KV.Value != nullptr)
-            NewClassificationMaterials.Add(*MaterialID, KV.Value);
-    }
-
-    FPLATEAUMeshLoaderForClassification MeshLoader(NewClassificationMaterials, false);
+    FPLATEAUMeshLoaderForClassification MeshLoader(CachedMaterials, false);
     return FPLATEAUModelReconstruct::ReconstructFromConvertedModelWithMeshLoader(MeshLoader, Model);
 }

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByAttribute.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByAttribute.cpp
@@ -46,13 +46,14 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByAttrib
     
     // ChachedMaterialに入っている元々のマテリアルに追加で、マテリアル分け用のマテリアルを追加
     TMap<int, UMaterialInterface*> ClassifyMatIDs;
-    for(const auto& [Attr, Mat] : ClassificationMaterials)
+    for (const auto& [Attr, Mat] : ClassificationMaterials)
     {
+        if (Mat == nullptr) continue;
         int id = CachedMaterials.Add(Mat);
-            Adjuster.registerMaterialPattern(TCHAR_TO_UTF8(*Attr), id);
+        Adjuster.registerMaterialPattern(TCHAR_TO_UTF8(*Attr), id);
     }
 
-    
+    // 変更が必要な属性値とマテリアルIDをC++側に登録
     auto meshes = converted.get()->getAllMeshes();
     for (auto& mesh : meshes) {
         auto cityObjList = mesh->getCityObjectList();
@@ -66,7 +67,7 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByAttrib
                 TSet<FString> AttributeStringValues = ConvertAttributeValuesToUniqueStringValues(AttributeValues);
                 
                 for (const auto& Value : AttributeStringValues) {
-                    if (ClassificationMaterials.Contains(Value)) {
+                    if (ClassificationMaterials.Contains(Value) && ClassificationMaterials[Value] != nullptr) {
 
                         Adjuster.registerAttribute(GmlId, TCHAR_TO_UTF8(*Value));
 

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByType.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByType.cpp
@@ -33,12 +33,13 @@ FPLATEAUModelClassificationByType::FPLATEAUModelClassificationByType(APLATEAUIns
     }
 }
 
-std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects) {
+std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects) {
 
     //最小地物単位のModelを生成
     std::shared_ptr<plateau::polygonMesh::Model> converted = ConvertModelWithGranularity(TargetCityObjects, ConvertGranularity::PerAtomicFeatureObject);
 
     //指定されたタイプのModelのSubMeshにGameMaterialIDを追加
+    // FIXME PLATEAUModelClassificationByAttribute.cppのようにCachedMaterialを使う用に変更すべき。マテリアル未指定の場合に対応するため。
     plateau::materialAdjust::MaterialAdjusterByType Adjuster;
     auto meshes = converted.get()->getAllMeshes();
     for (auto& mesh : meshes) {
@@ -78,13 +79,7 @@ void FPLATEAUModelClassificationByType::SetConvertGranularity(const ConvertGranu
 }
 
 TArray<USceneComponent*> FPLATEAUModelClassificationByType::ReconstructFromConvertedModel(std::shared_ptr<plateau::polygonMesh::Model> Model) {
-
-    TMap<int, UMaterialInterface*> NewClassificationMaterials;
-    for (const auto& KV : ClassificationMaterials) {
-        const int* MaterialID = MaterialIDMap.Find(KV.Key);
-        if (MaterialID != nullptr && KV.Value != nullptr)
-            NewClassificationMaterials.Add(*MaterialID, KV.Value);
-    }
-    FPLATEAUMeshLoaderForClassification MeshLoader(NewClassificationMaterials, false);
+    
+    FPLATEAUMeshLoaderForClassification MeshLoader(CachedMaterials, false);
     return FPLATEAUModelReconstruct::ReconstructFromConvertedModelWithMeshLoader(MeshLoader, Model);
 }

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByType.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByType.cpp
@@ -9,28 +9,13 @@
 
 using namespace plateau::granularityConvert;
 
-FPLATEAUModelClassificationByType::FPLATEAUModelClassificationByType() {}
 
 FPLATEAUModelClassificationByType::FPLATEAUModelClassificationByType(APLATEAUInstancedCityModel* Actor, const TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials)
 {
     CityModelActor = Actor;
     ClassificationMaterials = Materials;
     bDivideGrid = false;
-
-    //マテリアルごとにMaterial ID生成
-    // TMap<UMaterialInterface*, int> Material_MaterialIDMap;
-    // int ID = 0;
-    // for (const auto& KV : ClassificationMaterials) { //同一Materialを共通Material IDに
-    //     if (!Material_MaterialIDMap.Contains(KV.Value)) {
-    //         Material_MaterialIDMap.Add(KV.Value, ID);
-    //         ID++;
-    //     }
-    // }
-    //
-    // //属性の値ごとにMaterial IDをセット
-    // for (const auto& KV : ClassificationMaterials) {
-    //     MaterialIDMap.Add(KV.Key, Material_MaterialIDMap[KV.Value]);
-    // }
+    
 }
 
 std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects) {
@@ -48,12 +33,13 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::
     TMap<int, UMaterialInterface*> ClassifyMatIDs;
     for(const auto& [Type, Mat] : ClassificationMaterials)
     {
+        if(Mat == nullptr) continue;
         int id = CachedMaterials.Add(Mat);
         citygml::CityObject::CityObjectsType PlateauType = (citygml::CityObject::CityObjectsType)UPLATEAUCityObjectBlueprintLibrary::GetTypeAsInt64(Type);
         Adjuster.registerMaterialPattern(PlateauType, id);
     }
 
-    
+    // 変更が必要な地物型とマテリアルIDをC++側に登録
     auto meshes = converted.get()->getAllMeshes();
     for (auto& mesh : meshes) {
         auto cityObjList = mesh->getCityObjectList();
@@ -64,8 +50,7 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::
 
             if (const auto AttrInfoPtr = CityObjMap.Find(UTF8_TO_TCHAR(GmlId.c_str()))) {
                 const auto Type = AttrInfoPtr->Type;
-                if (ClassificationMaterials.Contains(Type)) {
-                    // const int MaterialID = ClassificationMaterials[Type];
+                if (ClassificationMaterials.Contains(Type) && ClassificationMaterials[Type] != nullptr) {
                     citygml::CityObject::CityObjectsType PlateauType = (citygml::CityObject::CityObjectsType)UPLATEAUCityObjectBlueprintLibrary::GetTypeAsInt64(Type);
                     Adjuster.registerType(GmlId, PlateauType);
             

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByType.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUModelClassificationByType.cpp
@@ -18,19 +18,19 @@ FPLATEAUModelClassificationByType::FPLATEAUModelClassificationByType(APLATEAUIns
     bDivideGrid = false;
 
     //マテリアルごとにMaterial ID生成
-    TMap<UMaterialInterface*, int> Material_MaterialIDMap;
-    int ID = 0;
-    for (const auto& KV : ClassificationMaterials) { //同一Materialを共通Material IDに
-        if (!Material_MaterialIDMap.Contains(KV.Value)) {
-            Material_MaterialIDMap.Add(KV.Value, ID);
-            ID++;
-        }
-    }
-
-    //属性の値ごとにMaterial IDをセット
-    for (const auto& KV : ClassificationMaterials) {
-        MaterialIDMap.Add(KV.Key, Material_MaterialIDMap[KV.Value]);
-    }
+    // TMap<UMaterialInterface*, int> Material_MaterialIDMap;
+    // int ID = 0;
+    // for (const auto& KV : ClassificationMaterials) { //同一Materialを共通Material IDに
+    //     if (!Material_MaterialIDMap.Contains(KV.Value)) {
+    //         Material_MaterialIDMap.Add(KV.Value, ID);
+    //         ID++;
+    //     }
+    // }
+    //
+    // //属性の値ごとにMaterial IDをセット
+    // for (const auto& KV : ClassificationMaterials) {
+    //     MaterialIDMap.Add(KV.Key, Material_MaterialIDMap[KV.Value]);
+    // }
 }
 
 std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects) {
@@ -39,23 +39,36 @@ std::shared_ptr<plateau::polygonMesh::Model> FPLATEAUModelClassificationByType::
     std::shared_ptr<plateau::polygonMesh::Model> converted = ConvertModelWithGranularity(TargetCityObjects, ConvertGranularity::PerAtomicFeatureObject);
 
     //指定されたタイプのModelのSubMeshにGameMaterialIDを追加
-    // FIXME PLATEAUModelClassificationByAttribute.cppのようにCachedMaterialを使う用に変更すべき。マテリアル未指定の場合に対応するため。
     plateau::materialAdjust::MaterialAdjusterByType Adjuster;
+
+    // CachedMaterialに元々のマテリアルを追加
+    ComposeCachedMaterialFromTarget(TargetCityObjects);
+
+    // ChachedMaterialに入っている元々のマテリアルに追加で、マテリアル分け用のマテリアルを追加
+    TMap<int, UMaterialInterface*> ClassifyMatIDs;
+    for(const auto& [Type, Mat] : ClassificationMaterials)
+    {
+        int id = CachedMaterials.Add(Mat);
+        citygml::CityObject::CityObjectsType PlateauType = (citygml::CityObject::CityObjectsType)UPLATEAUCityObjectBlueprintLibrary::GetTypeAsInt64(Type);
+        Adjuster.registerMaterialPattern(PlateauType, id);
+    }
+
+    
     auto meshes = converted.get()->getAllMeshes();
     for (auto& mesh : meshes) {
         auto cityObjList = mesh->getCityObjectList();
         for (auto& cityobj : cityObjList) {
 
             const auto GmlId = cityobj.second;
-            const auto AttrInfoPtr = CityObjMap.Find(UTF8_TO_TCHAR(GmlId.c_str()));
-            if (AttrInfoPtr) {
+
+
+            if (const auto AttrInfoPtr = CityObjMap.Find(UTF8_TO_TCHAR(GmlId.c_str()))) {
                 const auto Type = AttrInfoPtr->Type;
-                if (MaterialIDMap.Contains(Type)) {
-                    const int MaterialID = MaterialIDMap[Type];
+                if (ClassificationMaterials.Contains(Type)) {
+                    // const int MaterialID = ClassificationMaterials[Type];
                     citygml::CityObject::CityObjectsType PlateauType = (citygml::CityObject::CityObjectsType)UPLATEAUCityObjectBlueprintLibrary::GetTypeAsInt64(Type);
                     Adjuster.registerType(GmlId, PlateauType);
-                    Adjuster.registerMaterialPattern(PlateauType, MaterialID);
-
+            
                     const auto AttrInfo = *AttrInfoPtr;
                     TSet<FString> Children = FPLATEAUGmlUtil::GetChildrenGmlIds(AttrInfo);
                     for (auto ChildId : Children) {
@@ -79,6 +92,13 @@ void FPLATEAUModelClassificationByType::SetConvertGranularity(const ConvertGranu
 }
 
 TArray<USceneComponent*> FPLATEAUModelClassificationByType::ReconstructFromConvertedModel(std::shared_ptr<plateau::polygonMesh::Model> Model) {
+
+    // TMap<int, UMaterialInterface*> NewClassificationMaterials;
+    // for (const auto& KV : ClassificationMaterials) {
+    //     const int* MaterialID = MaterialIDMap.Find(KV.Key);
+    //     if (MaterialID != nullptr && KV.Value != nullptr)
+    //         NewClassificationMaterials.Add(*MaterialID, KV.Value);
+    // }
     
     FPLATEAUMeshLoaderForClassification MeshLoader(CachedMaterials, false);
     return FPLATEAUModelReconstruct::ReconstructFromConvertedModelWithMeshLoader(MeshLoader, Model);

--- a/Source/PLATEAURuntime/Public/PLATEAUCachedMaterialArray.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUCachedMaterialArray.h
@@ -1,0 +1,73 @@
+// Copyright 2023 Ministry of Land, Infrastructure and Transport
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * モデル変換で、あとでマテリアルを復元したい場合に使います。indexがマテリアルID、値がマテリアルです。
+ */
+class PLATEAURUNTIME_API FPLATEAUCachedMaterialArray
+{
+public:
+    /**
+     * 追加してそのインデックスを返します。
+     * ただし、すでに同じマテリアルが配列中にある場合は、追加せずにそのインデックスを返します。
+     */
+    int Add(TObjectPtr<UMaterialInterface> Mat)
+    {
+        if (Mat == nullptr)
+            return -1;
+
+        // 同じマテリアルが既に存在するかチェック
+        for (int i=0; i<Materials.Num(); i++)
+        {
+            const auto& Material = Materials[i];
+            if (Material == Mat)
+                return i;
+        }
+
+        // 存在しない場合は追加
+        Materials.Add(Mat);
+        return Materials.Num() - 1;
+    }
+
+    TObjectPtr<UMaterialInterface> Get(int Index)
+    {
+        return Materials[Index];
+    }
+
+    int Num()
+    {
+        return Materials.Num();
+    }
+
+    /**
+     * キャッシュされたマテリアルをすべてクリアします。
+     */
+    void Clear()
+    {
+        Materials.Empty();
+    }
+
+    /**
+     * 配列からMatを探してそのインデックスを返します。なければ-1を返します。
+     */
+    int IndexOf(TObjectPtr<UMaterialInterface> Mat)
+    {
+        if (Mat == nullptr)
+            return -1;
+
+        // 配列から同じマテリアルを探す
+        for (int i = 0; i < Materials.Num(); i++)
+        {
+            const auto& Material = Materials[i];
+            if (Material == Mat)
+                return i;
+        }
+
+        return -1;
+    }
+private:
+    TArray<TObjectPtr<UMaterialInterface>> Materials;
+};

--- a/Source/PLATEAURuntime/Public/PLATEAUInstancedCityModel.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUInstancedCityModel.h
@@ -158,26 +158,26 @@ public:
      * @brief 選択されたComponentの結合・分割処理を行います。
      * @param 
      */
-    UE::Tasks::TTask<TArray<USceneComponent*>> ReconstructModel(const TArray<USceneComponent*> TargetComponents, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
+    UE::Tasks::TTask<TArray<USceneComponent*>> ReconstructModel(const TArray<USceneComponent*>& TargetComponents, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
 
 
     /**
      * @brief 選択されたComponentのMaterialをCityObjectのTypeごとに分割します
      * @param
      */
-    UE::Tasks::TTask<TArray<USceneComponent*>> ClassifyModel(const TArray<USceneComponent*> TargetComponents, TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
+    UE::Tasks::TTask<TArray<USceneComponent*>> ClassifyModel(const TArray<USceneComponent*>& TargetComponents, TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
 
     /**
      * @brief 選択されたComponentのMaterialを属性情報のKeyに紐づく値で分割します
      * @param
      */
-    UE::Tasks::TTask<TArray<USceneComponent*>> ClassifyModel(const TArray<USceneComponent*> TargetComponents, const FString AttributeKey, TMap<FString, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
+    UE::Tasks::TTask<TArray<USceneComponent*>> ClassifyModel(const TArray<USceneComponent*>& TargetComponents, const FString& AttributeKey, TMap<FString, UMaterialInterface*> Materials, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
 
     /**
      * @brief 選択されたComponentからLandscapeを生成します
      * @param
      */
-	UE::Tasks::FTask CreateLandscape(const TArray<USceneComponent*> TargetComponents, FPLATEAULandscapeParam Param, bool bDestroyOriginal);
+	UE::Tasks::FTask CreateLandscape(const TArray<USceneComponent*>& TargetComponents, FPLATEAULandscapeParam Param, bool bDestroyOriginal);
 
 protected:
     // Called when the game starts or when spawned
@@ -191,17 +191,17 @@ protected:
     /**
      * @brief 結合分離　共通処理
      */
-    UE::Tasks::TTask<TArray<USceneComponent*>> ReconstructTask(FPLATEAUModelReconstruct& ModelReconstruct, const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects, bool bDestroyOriginal);
+    UE::Tasks::TTask<TArray<USceneComponent*>> ReconstructTask(FPLATEAUModelReconstruct& ModelReconstruct, const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects, bool bDestroyOriginal);
 
     /**
      * @brief マテリアル分け　共通処理
      */
-    UE::Tasks::TTask<TArray<USceneComponent*>> ClassifyTask(FPLATEAUModelClassification& ModelClassification, const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
+    UE::Tasks::TTask<TArray<USceneComponent*>> ClassifyTask(FPLATEAUModelClassification& ModelClassification, const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects, const EPLATEAUMeshGranularity ReconstructType, bool bDestroyOriginal);
 
     /**
      * @brief 特定パッケージを地形に合わせて高さ合わせ
      */
-    TArray<UPLATEAUCityObjectGroup*> AlignLand(TArray<HeightmapCreationResult>& Results, FPLATEAULandscapeParam Param, bool bDestroyOriginal);
+    TArray<UPLATEAUCityObjectGroup*> AlignLand(TArray<HeightmapCreationResult>& Results, const FPLATEAULandscapeParam& Param, bool bDestroyOriginal);
 
     /**
      * @brief 属性情報の有無を取得します。

--- a/Source/PLATEAURuntime/Public/PLATEAUMeshExporter.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUMeshExporter.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Component/PLATEAUCityObjectGroup.h"
+#include "PLATEAUCachedMaterialArray.h"
 #include "plateau/mesh_writer/gltf_writer.h"
 #include "plateau/mesh_writer/fbx_writer.h"
 
@@ -20,10 +21,12 @@ namespace plateau {
     }
 }
 
+
 class PLATEAURUNTIME_API FPLATEAUMeshExporter {
 public:
-    bool Export(const FString ExportPath, APLATEAUInstancedCityModel* ModelActor, const FPLATEAUMeshExportOptions& Option);
+    bool Export(const FString& ExportPath, APLATEAUInstancedCityModel* ModelActor, const FPLATEAUMeshExportOptions& Option);
     std::shared_ptr<plateau::polygonMesh::Model> CreateModelFromComponents(APLATEAUInstancedCityModel* ModelActor, const TArray<UPLATEAUCityObjectGroup*> ModelComponents, const FPLATEAUMeshExportOptions Option);
+    const FPLATEAUCachedMaterialArray& GetCachedMaterials(){ return CachedMaterials; }
 
 private:
     bool ExportAsOBJ(const FString& ExportPath, APLATEAUInstancedCityModel* ModelActor, const FPLATEAUMeshExportOptions& Option);
@@ -37,4 +40,5 @@ private:
     TArray<FString> ModelNames;
     FVector ReferencePoint;
     APLATEAUInstancedCityModel* TargetActor = nullptr;
+    FPLATEAUCachedMaterialArray CachedMaterials;
 };

--- a/Source/PLATEAURuntime/Public/PLATEAUMeshLoader.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUMeshLoader.h
@@ -81,7 +81,7 @@ public:
     TArray<USceneComponent*> GetLastCreatedComponents();
 
 protected:
-    // SubMesh情報等に応じてMaterialを作成
+    // SubMesh情報等に応じてMaterialを作成します。
     virtual UMaterialInterface* GetMaterialForSubMesh(const FSubMeshMaterialSet& SubMeshValue, UStaticMeshComponent* Component, const FLoadInputData& LoadInputData, UTexture2D* Texture, FNodeHierarchy NodeHier);
     // Loaderのタイプに応じて異なるStaticMeshComponentを作成
     virtual UStaticMeshComponent* GetStaticMeshComponentForCondition(AActor& Actor, EName Name, FNodeHierarchy NodeHier,

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUMeshLoaderForClassification.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUMeshLoaderForClassification.h
@@ -2,18 +2,20 @@
 
 #pragma once
 
+#include "PLATEAUCachedMaterialArray.h"
 #include "PLATEAUMeshLoaderForReconstruct.h"
 
 class PLATEAURUNTIME_API FPLATEAUMeshLoaderForClassification : public FPLATEAUMeshLoaderForReconstruct {
 
 public:
-    FPLATEAUMeshLoaderForClassification(const TMap<int, UMaterialInterface*> Materials);
-    FPLATEAUMeshLoaderForClassification(const TMap<int, UMaterialInterface*> Materials, const bool InbAutomationTest);
+    FPLATEAUMeshLoaderForClassification(const FPLATEAUCachedMaterialArray Mats);
+    FPLATEAUMeshLoaderForClassification(const FPLATEAUCachedMaterialArray Mats, const bool InbAutomationTest);
 
 protected:
     UMaterialInterface* GetMaterialForSubMesh(const FSubMeshMaterialSet& SubMeshValue, UStaticMeshComponent* Component, const FLoadInputData& LoadInputData, UTexture2D* Texture, FNodeHierarchy NodeHier) override;
+    
 private:
-
-    //Material分け時のマテリアルリスト
-    TMap<int, UMaterialInterface*> ClassificationMaterials;
+    
+    //Material分け時のマテリアルリスト。
+    FPLATEAUCachedMaterialArray CachedMaterials;
 };

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByAttribute.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByAttribute.h
@@ -10,17 +10,16 @@
 class PLATEAURUNTIME_API FPLATEAUModelClassificationByAttribute : public FPLATEAUModelClassification {
 
 public:
-    FPLATEAUModelClassificationByAttribute();
-    FPLATEAUModelClassificationByAttribute(APLATEAUInstancedCityModel* Actor, const FString AttributeKey, const TMap<FString, UMaterialInterface*> Materials);
+    FPLATEAUModelClassificationByAttribute(APLATEAUInstancedCityModel* Actor, const FString& AttributeKey, const TMap<FString, UMaterialInterface*>& Materials);
     void SetConvertGranularity(const ConvertGranularity Granularity) override;
 
-    std::shared_ptr<plateau::polygonMesh::Model> ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects) override;
+    std::shared_ptr<plateau::polygonMesh::Model> ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects) override;
     TArray<USceneComponent*> ReconstructFromConvertedModel(std::shared_ptr<plateau::polygonMesh::Model> Model) override;
 
 protected:
 
     FString ClassificationAttributeKey;
     TMap<FString, UMaterialInterface*> ClassificationMaterials;
-    TMap<FString, int> MaterialIDMap;
+    // TMap<FString, int> MaterialIDMap;
 };
 

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByAttribute.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByAttribute.h
@@ -6,7 +6,10 @@
 #include "Reconstruct/PLATEAUModelClassification.h"
 #include <plateau/material_adjust/material_adjuster_by_attr.h>
 
-//マテリアル分け（属性）
+/**
+ * 属性によるマテリアル分けを行います。
+ * 類似クラスとして FPLATEAUModelClassificationByType があります。
+ */
 class PLATEAURUNTIME_API FPLATEAUModelClassificationByAttribute : public FPLATEAUModelClassification {
 
 public:
@@ -20,6 +23,5 @@ protected:
 
     FString ClassificationAttributeKey;
     TMap<FString, UMaterialInterface*> ClassificationMaterials;
-    // TMap<FString, int> MaterialIDMap;
 };
 

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByType.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByType.h
@@ -13,7 +13,7 @@ public:
     FPLATEAUModelClassificationByType(APLATEAUInstancedCityModel* Actor, const TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials);
     void SetConvertGranularity(const ConvertGranularity Granularity) override;
 
-    std::shared_ptr<plateau::polygonMesh::Model> ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects) override;
+    std::shared_ptr<plateau::polygonMesh::Model> ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects) override;
     TArray<USceneComponent*> ReconstructFromConvertedModel(std::shared_ptr<plateau::polygonMesh::Model> Model) override;
 
 protected:

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByType.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByType.h
@@ -5,11 +5,13 @@
 #include "CoreMinimal.h"
 #include "Reconstruct/PLATEAUModelClassification.h"
 
-//マテリアル分け（タイプ）
+/**
+ * 地物型によるマテリアル分けを行います。
+ * 類似クラスとして FPLATEAUModelClassificationByAttribute があります。
+ */
 class PLATEAURUNTIME_API FPLATEAUModelClassificationByType : public FPLATEAUModelClassification {
 
 public:
-    FPLATEAUModelClassificationByType();
     FPLATEAUModelClassificationByType(APLATEAUInstancedCityModel* Actor, const TMap<EPLATEAUCityObjectsType, UMaterialInterface*> Materials);
     void SetConvertGranularity(const ConvertGranularity Granularity) override;
 
@@ -19,5 +21,4 @@ public:
 protected:
 
     TMap<EPLATEAUCityObjectsType, UMaterialInterface*> ClassificationMaterials;
-    // TMap<EPLATEAUCityObjectsType, int> MaterialIDMap;
 };

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByType.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelClassificationByType.h
@@ -19,5 +19,5 @@ public:
 protected:
 
     TMap<EPLATEAUCityObjectsType, UMaterialInterface*> ClassificationMaterials;
-    TMap<EPLATEAUCityObjectsType, int> MaterialIDMap;
+    // TMap<EPLATEAUCityObjectsType, int> MaterialIDMap;
 };

--- a/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelReconstruct.h
+++ b/Source/PLATEAURuntime/Public/Reconstruct/PLATEAUModelReconstruct.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "PLATEAUCachedMaterialArray.h"
 #include "PLATEAUInstancedCityModel.h"
 #include "PLATEAUMeshLoaderForReconstruct.h"
 #include "Util/PLATEAUReconstructUtil.h"
@@ -29,13 +30,15 @@ public:
      * @brief 選択されたComponentの結合・分割処理用のModelを生成します
      * @param
      */
-    virtual std::shared_ptr<plateau::polygonMesh::Model> ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects);
+    virtual std::shared_ptr<plateau::polygonMesh::Model> ConvertModelForReconstruct(const TArray<UPLATEAUCityObjectGroup*>& TargetCityObjects);
 
     /**
      * @brief 生成されたModelからStaticMeshコンポーネントを再生成します
      * @param
      */
     virtual TArray<USceneComponent*> ReconstructFromConvertedModel(std::shared_ptr<plateau::polygonMesh::Model> Model);
+
+    void ComposeCachedMaterialFromTarget(const TArray<UPLATEAUCityObjectGroup*>& Target);
 
 protected:
     
@@ -58,5 +61,9 @@ protected:
     TArray<USceneComponent*> ReconstructFromConvertedModelWithMeshLoader(FPLATEAUMeshLoaderForReconstruct& MeshLoader, std::shared_ptr<plateau::polygonMesh::Model> Model);
 
     virtual std::shared_ptr<plateau::polygonMesh::Model> ConvertModelWithGranularity(const TArray<UPLATEAUCityObjectGroup*> TargetCityObjects, const ConvertGranularity Granularity);
-
+    
+    /**
+     * @brief 変換後にマテリアルを復元する用です
+     */
+    FPLATEAUCachedMaterialArray CachedMaterials;
 };

--- a/Source/PLATEAUTests/Tests/Reconstruct/PLATEAUMeshLoaderClassificationTest.cpp
+++ b/Source/PLATEAUTests/Tests/Reconstruct/PLATEAUMeshLoaderClassificationTest.cpp
@@ -14,16 +14,16 @@
 
 namespace FPLATEAUTest_MeshLoader_Classification_Local {
 
-    const int MATERIAL_ID = 1;
+    constexpr int DISASTER_MAT_ID = 0;
 
-    //Material ID 1のMap生成
-    TMap<int, UMaterialInterface*> CreateMaterialMap() {
-        TMap<int, UMaterialInterface*> Materials;
+    //DisasterMaterialのマテリアルキャッシュ
+    FPLATEAUCachedMaterialArray CreateMaterialMap() {
+        FPLATEAUCachedMaterialArray Result;
         FString SourcePath = TEXT("/PLATEAU-SDK-for-Unreal/Materials/Fallback/PlateauDefaultDisasterMaterialInstance");
         UMaterialInstance* Material = Cast<UMaterialInstance>(
             StaticLoadObject(UMaterialInstance::StaticClass(), nullptr, *SourcePath));
-        Materials.Add(MATERIAL_ID, Material);
-        return Materials;
+        Result.Add(Material);
+        return Result;
     }
 
     //MeshにMaterial ID 付与してMesh生成
@@ -37,7 +37,7 @@ namespace FPLATEAUTest_MeshLoader_Classification_Local {
         }
         Mesh.addIndicesList(indices, 0, false);
         Mesh.addVerticesList(vertices);
-        Mesh.addSubMesh("", nullptr, 0, indices.size() - 1, MATERIAL_ID);
+        Mesh.addSubMesh("", nullptr, 0, indices.size() - 1, DISASTER_MAT_ID);
         Mesh.addUV1(uv1, vertices.size());
         Mesh.addUV4WithSameVal(TVec2f(0, 1), vertices.size());
         Mesh.setCityObjectList(CityObj);
@@ -73,7 +73,7 @@ bool FPLATEAUTest_MeshLoader_Classification::RunTest(const FString& Parameters) 
     TAtomic<bool> bCanceled;
     bCanceled.Store(false);
 
-    TMap<int, UMaterialInterface*> Materials = FPLATEAUTest_MeshLoader_Classification_Local::CreateMaterialMap();
+    FPLATEAUCachedMaterialArray Materials = FPLATEAUTest_MeshLoader_Classification_Local::CreateMaterialMap();
     FPLATEAUMeshLoaderForClassification MeshLoader(Materials);
 
     MeshLoader.ReloadComponentFromModel(Model, ConvGranularity, CityObj, *Actor);


### PR DESCRIPTION
- マテリアル分け機能のバグを修正し、したがって道路ネットワークを複数回やったときに道路のマテリアルが剥がれる問題を解決しました
- 例えば属性情報Aをキーとしてマテリアル分けするとき、属性キーAを含むものと含まないものを両方選択してマテリアル分けすると、属性キーAを含まないもののマテリアルが剥がれる問題を修正し、前のマテリアルが維持されるようにしました
- 地物型でのマテリアル分けも同様に修正しました
