### PR TITLE
横断歩道の頻度オプションを実装

### DIFF
--- a/Content/EUW/RoadAdjsutmentGenerateTab.uasset
+++ b/Content/EUW/RoadAdjsutmentGenerateTab.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a92be8c9a807263286b86489bc5b2400dd597f7c793bb15524ae6cc6523969eb
-size 499367
+oid sha256:483cca2aafe999504099be4a071b7aa9b9bbd10e31aae3afc59efda7375810bd
+size 509852

--- a/Source/PLATEAURuntime/Private/RoadAdjust/PLATEAUCrosswalkPlacementRule.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/PLATEAUCrosswalkPlacementRule.cpp
@@ -60,3 +60,16 @@ TSharedPtr<IPLATEAUCrosswalkPlacementRule> FPLATEAUCrosswalkFrequencyExtensions:
             return nullptr;
     }
 }
+
+EPLATEAUCrosswalkFrequency FPLATEAUCrosswalkFrequencyExtensions::StrToFrequency(const FString& Str)
+{
+    if (Str == TEXT("大きい道路に配置") || Str == TEXT("") /* 初期値 */)
+        return EPLATEAUCrosswalkFrequency::BigRoad;
+    if (Str == TEXT("すべての交差点に配置"))
+        return EPLATEAUCrosswalkFrequency::All;
+    if (Str == TEXT("配置しない"))
+        return EPLATEAUCrosswalkFrequency::None;
+    
+    UE_LOG(LogTemp, Error, TEXT("Unknown CrosswalkFrequency: %s"), *Str);
+    return EPLATEAUCrosswalkFrequency::None;
+}

--- a/Source/PLATEAURuntime/Private/RoadAdjust/PLATEAUReproducedRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/PLATEAUReproducedRoad.cpp
@@ -7,6 +7,7 @@
 #include "RoadAdjust/RoadMarking/LineGeneratorComponent.h"
 #include "RoadAdjust/RoadMarking/PLATEAUCrosswalkComposer.h"
 #include "RoadAdjust/RoadMarking/PLATEAUMarkedWayListComposerMain.h"
+#include "RoadAdjust/PLATEAUCrosswalkPlacementRule.h"
 #include "RoadAdjust/RoadNetworkToMesh/PLATEAURrTarget.h"
 #include "RoadNetwork/Structure/RnModel.h"
 #include "RoadNetwork/Structure/PLATEAURnStructureModel.h"
@@ -34,7 +35,7 @@ void APLATEAUReproducedRoad::CreateLineTypeMap() {
     LineTypeMap.Add(EPLATEAURoadLineType::Crossing, PLATEAURoadLineTypeExtension::ToRoadLineParam(EPLATEAURoadLineType::Crossing, LineMesh, TileMesh));
 }
 
-void APLATEAUReproducedRoad::CreateRoadMarks(APLATEAURnStructureModel* Model) {
+void APLATEAUReproducedRoad::CreateRoadMarks(APLATEAURnStructureModel* Model, FString CrosswalkFrequency) {
 
     auto RnModel = Model->Model;
 
@@ -47,7 +48,7 @@ void APLATEAUReproducedRoad::CreateRoadMarks(APLATEAURnStructureModel* Model) {
     auto MarkedWays = WayComposer->ComposeFrom(TargetModel).GetMarkedWays();
 
     // 横断歩道
-    auto CrossRoads = NewObject<UPLATEAUCrosswalkComposer>()->Compose(*TargetModel, EPLATEAUCrosswalkFrequency::BigRoad);
+    auto CrossRoads = NewObject<UPLATEAUCrosswalkComposer>()->Compose(*TargetModel, FPLATEAUCrosswalkFrequencyExtensions::StrToFrequency(CrosswalkFrequency));
     MarkedWays.Append(CrossRoads.GetMarkedWays());
 
     // 白線を生成

--- a/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUCrosswalkComposer.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUCrosswalkComposer.cpp
@@ -90,8 +90,7 @@ FPLATEAUMarkedWayList UPLATEAUCrosswalkComposer::GenerateCrosswalk(
     // 横断歩道を1本の破線として生成します。
     auto CrosswalkLine = FPLATEAUMWLine(CrosswalkPositions);
     auto MarkedWay = FPLATEAUMarkedWay(CrosswalkLine, EPLATEAUMarkedWayType::Crosswalk, false);
-    // auto Generator = FDashedLineMeshGenerator(ERoadMarkingMaterial::White, true, CrosslineWidth, CrosslineDashInterval);
-    // const auto Crosswalk = Generator.GenerateMeshInstance(CrosswalkPositions);
+
     Result.Add(MarkedWay);
 
     return Result;

--- a/Source/PLATEAURuntime/Public/RoadAdjust/PLATEAUCrosswalkPlacementRule.h
+++ b/Source/PLATEAURuntime/Public/RoadAdjust/PLATEAUCrosswalkPlacementRule.h
@@ -21,6 +21,7 @@ enum class EPLATEAUCrosswalkFrequency : uint8 {
     Delete UMETA(DisplayName = "Delete"),
 };
 
+
 /**
 * @brief 横断歩道を設置する条件を表す基底クラスです。
 * 設置すべきときにメソッドShouldPlaceがtrueとなるようにサブクラスを実装します。
@@ -75,4 +76,5 @@ public:
 class PLATEAURUNTIME_API FPLATEAUCrosswalkFrequencyExtensions {
 public:
     static TSharedPtr<IPLATEAUCrosswalkPlacementRule> ToPlacementRule(EPLATEAUCrosswalkFrequency Frequency);
+    static EPLATEAUCrosswalkFrequency StrToFrequency(const FString& Str);
 };

--- a/Source/PLATEAURuntime/Public/RoadAdjust/PLATEAUReproducedRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadAdjust/PLATEAUReproducedRoad.h
@@ -64,7 +64,7 @@ public:
 
     /// 道路標示を生成します。
     UFUNCTION(BlueprintCallable, meta = (Category = "PLATEAU|RoadAdjust"))
-    void CreateRoadMarks(APLATEAURnStructureModel* Model);
+    void CreateRoadMarks(APLATEAURnStructureModel* Model, FString CrosswalkFrequency);
 
 
 protected:

--- a/Source/PLATEAURuntime/Public/RoadAdjust/RoadMarking/PLATEAUCrosswalkComposer.h
+++ b/Source/PLATEAURuntime/Public/RoadAdjust/RoadMarking/PLATEAUCrosswalkComposer.h
@@ -10,34 +10,6 @@
 #include "RoadAdjust/RoadNetworkToMesh/PLATEAURrTarget.h"
 #include "PLATEAUCrosswalkComposer.generated.h"
 
-// USTRUCT()
-// struct PLATEAURUNTIME_API FPLATEAUCrosswalkInstance {
-//     GENERATED_BODY()
-// public:
-//     FPLATEAUCrosswalkInstance() = default;
-//     FPLATEAUCrosswalkInstance(const TSharedPtr<FRoadMarkingInstance>& InRoadMarkingInstance, 
-//         const TSharedPtr<URnRoadBase>& InSrcRoad, 
-//         EPLATEAUReproducedRoadDirection InDirection)
-//         : RoadMarkingInstance(InRoadMarkingInstance)
-//         , SrcRoad(InSrcRoad)
-//         , Direction(InDirection)
-//     {}
-//
-//     TSharedPtr<FRoadMarkingInstance> GetRoadMarkingInstance() const { return RoadMarkingInstance; }
-//     TSharedPtr<URnRoadBase> GetSrcRoad() const { return SrcRoad; }
-//     EPLATEAUReproducedRoadDirection GetDirection() const { return Direction; }
-//
-// private:
-//     UPROPERTY()
-//     TSharedPtr<FRoadMarkingInstance> RoadMarkingInstance;
-//
-//     UPROPERTY()
-//     TSharedPtr<URnRoadBase> SrcRoad;
-//
-//     UPROPERTY()
-//     EPLATEAUReproducedRoadDirection Direction;
-// };
-
 UCLASS()
 class PLATEAURUNTIME_API UPLATEAUCrosswalkComposer : public UObject {
     GENERATED_BODY()

--- a/Source/PLATEAURuntime/Public/RoadAdjust/RoadMarking/PLATEAUDirectionalArrowComposer.h
+++ b/Source/PLATEAURuntime/Public/RoadAdjust/RoadMarking/PLATEAUDirectionalArrowComposer.h
@@ -26,8 +26,8 @@ public:
     TArray<TObjectPtr<UStaticMeshComponent>> Compose();
 
 private:
-    static constexpr float ArrowMeshHeightOffset = 7.0f; // 7cm
-    static constexpr float ArrowPositionOffset = 450.0f; // 4.5m 
+    static constexpr float ArrowMeshHeightOffset = 9.0f; // cm
+    static constexpr float ArrowPositionOffset = 450.0f; // cm 
 
     TObjectPtr<UStaticMeshComponent> GenerateArrow(const URnWay* LaneBorder, const URnIntersection* Intersection,
                                                   const FVector& Position, float Rotation);

--- a/Source/PLATEAURuntime/Public/RoadAdjust/RoadMarking/PLATEAUMarkedWayListComposerMain.h
+++ b/Source/PLATEAURuntime/Public/RoadAdjust/RoadMarking/PLATEAUMarkedWayListComposerMain.h
@@ -41,7 +41,7 @@ public:
     virtual FPLATEAUMarkedWayList ComposeFrom(const IPLATEAURrTarget* Target) override;
     
     // 経験的にこのくらいの高さなら道路にめりこまないという値
-    static constexpr float HeightOffset = 7.0f;
+    static constexpr float HeightOffset = 9.0f;
 
 private:
     


### PR DESCRIPTION
道路ネットワーク生成時のオプションで、
「横断歩道の配置」オプションで次の3つから選択できるようにしました。
- 大きい道路に配置
- すべての交差点に配置
- 配置しない