### PR TITLE
交差点の停止線をずらす処理が歩道があるときに切断チェックに失敗するケースを修正

### DIFF
--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment2D.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment2D.cpp
@@ -80,9 +80,9 @@ bool FLineSegment2D::TryHalfLineIntersection(const FVector2D& Origin, const FVec
 }
 
 bool FLineSegment2D::TryLineIntersection(const FVector2D& Origin, const FVector2D& Dir,
-    FVector2D& OutIntersection, float& OutLineLength, float& OutSegmentT) const
+    FVector2D& OutIntersection, float& OutLineOffset, float& OutSegmentT) const
 {
-    return FLineUtil::LineSegmentIntersection(FRay2D(Origin, Dir), Start, End, OutIntersection, OutLineLength, OutSegmentT);
+    return FLineUtil::LineSegmentIntersection(FRay2D(Origin, Dir), Start, End, OutIntersection, OutLineOffset, OutSegmentT);
 }
 
 float FLineSegment2D::GetDistance(const FLineSegment2D& Other) const {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment2D.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment2D.cpp
@@ -74,15 +74,15 @@ bool FLineSegment2D::TrySegmentIntersection(const FLineSegment2D& Other) const
 }
 
 bool FLineSegment2D::TryHalfLineIntersection(const FVector2D& Origin, const FVector2D& Dir, FVector2D& OutIntersection,
-    float& OutT1, float& OutT2) const
+    float& OutHalfLineOffset, float& OutSegmentT) const
 {
-    return FLineUtil::HalfLineSegmentIntersection(FRay2D(Origin, Dir), Start, End, OutIntersection, OutT1, OutT2);
+    return FLineUtil::HalfLineSegmentIntersection(FRay2D(Origin, Dir), Start, End, OutIntersection, OutHalfLineOffset, OutSegmentT);
 }
 
 bool FLineSegment2D::TryLineIntersection(const FVector2D& Origin, const FVector2D& Dir,
-    FVector2D& OutIntersection, float& OutT1, float& OutT2) const
+    FVector2D& OutIntersection, float& OutLineLength, float& OutSegmentT) const
 {
-    return FLineUtil::LineSegmentIntersection(FRay2D(Origin, Dir), Start, End, OutIntersection, OutT1, OutT2);
+    return FLineUtil::LineSegmentIntersection(FRay2D(Origin, Dir), Start, End, OutIntersection, OutLineLength, OutSegmentT);
 }
 
 float FLineSegment2D::GetDistance(const FLineSegment2D& Other) const {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment3D.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment3D.cpp
@@ -35,21 +35,21 @@ FVector FLineSegment3D::GetNearestPoint(const FVector& Point, float& OutDistance
 }
 
 bool FLineSegment3D::TryLineIntersectionBy2D(const FVector& Origin, const FVector& Dir, EAxisPlane Plane,
-    float NormalTolerance, FVector& OutIntersection, float& OutLineLength, float& OutSegmentT) const
+    float NormalTolerance, FVector& OutIntersection, float& OutLineOffset, float& OutSegmentT) const
 {
     auto Self2D = To2D(Plane);
     FVector2D Inter2D;
     if (!Self2D.TryLineIntersection(
         FAxisPlaneEx::ToVector2D(Origin, Plane)
         , FAxisPlaneEx::ToVector2D(Dir, Plane)
-        , Inter2D, OutLineLength, OutSegmentT)) {
+        , Inter2D, OutLineOffset, OutSegmentT)) {
         return false;
     }
 
     const float Y1 = 
         FMath::Lerp(FAxisPlaneEx::GetNormal(Start, Plane),
         FAxisPlaneEx::GetNormal(End, Plane), OutSegmentT);
-    const float Y2 = FAxisPlaneEx::GetNormal(Origin, Plane) + FAxisPlaneEx::GetNormal(Dir, Plane) * OutLineLength;
+    const float Y2 = FAxisPlaneEx::GetNormal(Origin, Plane) + FAxisPlaneEx::GetNormal(Dir, Plane) * OutLineOffset;
     if (FMath::Abs(Y2 - Y1) > NormalTolerance && NormalTolerance >= 0.0f) {
         return false;
     }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment3D.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineSegment3D.cpp
@@ -35,20 +35,21 @@ FVector FLineSegment3D::GetNearestPoint(const FVector& Point, float& OutDistance
 }
 
 bool FLineSegment3D::TryLineIntersectionBy2D(const FVector& Origin, const FVector& Dir, EAxisPlane Plane,
-    float NormalTolerance, FVector& OutIntersection, float& OutT1, float& OutT2) const
+    float NormalTolerance, FVector& OutIntersection, float& OutLineLength, float& OutSegmentT) const
 {
     auto Self2D = To2D(Plane);
     FVector2D Inter2D;
     if (!Self2D.TryLineIntersection(
         FAxisPlaneEx::ToVector2D(Origin, Plane)
         , FAxisPlaneEx::ToVector2D(Dir, Plane)
-        , Inter2D, OutT1, OutT2)) {
+        , Inter2D, OutLineLength, OutSegmentT)) {
         return false;
     }
 
-    const float Y1 = FMath::Lerp(FAxisPlaneEx::GetNormal(Start, Plane),
-        FAxisPlaneEx::GetNormal(End, Plane), OutT1);
-    const float Y2 = FAxisPlaneEx::GetNormal(Origin, Plane) + FAxisPlaneEx::GetNormal(Dir, Plane) * OutT2;
+    const float Y1 = 
+        FMath::Lerp(FAxisPlaneEx::GetNormal(Start, Plane),
+        FAxisPlaneEx::GetNormal(End, Plane), OutSegmentT);
+    const float Y2 = FAxisPlaneEx::GetNormal(Origin, Plane) + FAxisPlaneEx::GetNormal(Dir, Plane) * OutLineLength;
     if (FMath::Abs(Y2 - Y1) > NormalTolerance && NormalTolerance >= 0.0f) {
         return false;
     }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLineString.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLineString.cpp
@@ -496,10 +496,10 @@ TArray<TTuple<float, FVector>> URnLineString::GetIntersectionBy2D(const FRay& Ra
     for (auto i = 0; i < Edges.Num(); ++i) {
         auto E = Edges[i];
         FVector P;
-        float T1;
-        float T2;
-        if (E.TryLineIntersectionBy2D(Ray.Origin, Ray.Direction, Plane, -1.f, P, T1, T2)) {
-            Result.Add(MakeTuple(i + T1, P));
+        float LineLength;
+        float SegmentT;
+        if (E.TryLineIntersectionBy2D(Ray.Origin, Ray.Direction, Plane, -1.f, P, LineLength, SegmentT)) {
+            Result.Add(MakeTuple(i + SegmentT, P));
         }
     }
 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -206,8 +206,9 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
         return false;
     }
 
-    if (!Road->IsAllLaneValid())
+    if (!Road->IsAllLaneValid()) {
         return false;
+    }
 
     URnWay* LeftWay = nullptr;
     URnWay* RightWay = nullptr;
@@ -226,8 +227,7 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
     auto IsNeighbor = [&](URnRoad* r, URnIntersection* neighbor) {
         return r->Next == neighbor || r->Prev == neighbor;
         };
-    struct SideInfo
-    {
+    struct SideInfo {
         URnRoad* FarSide = nullptr;
         URnRoad* NearSide = nullptr;
     };
@@ -241,8 +241,7 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
         };
 
     TArray<FNeighborInfo> Neighbors;
-    for (EPLATEAURnLaneBorderType BorderType : {EPLATEAURnLaneBorderType::Prev, EPLATEAURnLaneBorderType::Next})
-    {
+    for (EPLATEAURnLaneBorderType BorderType : {EPLATEAURnLaneBorderType::Prev, EPLATEAURnLaneBorderType::Next}) {
         if (URnIntersection* Intersection = Cast<URnIntersection>(Road->GetNeighborRoad(BorderType))) {
             Neighbors.Add({ Intersection, BorderType });
         }
@@ -255,8 +254,10 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
     const float OffsetLength = FMath::Max(1.0f,
         FMath::Min(MaxOffset, (MinLength - NeedRoadLengthMeter) / Neighbors.Num()));
 
+    auto Success = true;
     if (URnIntersection* NextIntersection = Cast<URnIntersection>(Road->GetNext())) {
         FLineSegment3D Segment;
+
         if (Road->TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType::Next, OffsetLength, Segment)) {
             FSliceRoadHorizontalResult Result = SliceRoadHorizontal(Road, Segment);
             if (Result.Result == ERoadCutResult::Success) {
@@ -265,6 +266,12 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
                 OutNextSideRoad = Check.NearSide;
                 Road = Check.FarSide;
             }
+            else {
+                Success = false;
+            }
+        }
+        else {
+            Success = false;
         }
     }
 
@@ -277,10 +284,16 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
                 OutCenterSideRoad = Check.FarSide;
                 OutPrevSideRoad = Check.NearSide;
             }
+            else {
+                Success = false;
+            }
+        }
+        else {
+            Success = false;
         }
     }
-
-    return true;
+    
+    return Success;
 }
 
 
@@ -570,7 +583,8 @@ URnModel::ERoadCutResult URnModel::CanSliceRoadHorizontal(URnRoad* Road, const F
 
         // 歩道は角の道だったりすると前後で分かれていたりするので交わらない場合もある
         // ただし、inside/outsideがどっちも交わるかどっちも交わらないかしか許さない
-        auto SliceCount = Algo::CountIf(Sw->GetSideWays(), [&](URnWay* Way) {
+        auto SwSideWays = Sw->GetSideWays();
+        auto SliceCount = Algo::CountIf(SwSideWays, [&](URnWay* Way) {
             return IsSliced(Way);
         });
         if (!(SliceCount == 0 || SliceCount == 2)) {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
@@ -492,6 +492,7 @@ bool URnRoad::TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType BorderSide, fl
     URnWay* LeftWay = nullptr;
     URnWay* RightWay = nullptr;
     if (!TryGetMergedSideWay(NullOpt, LeftWay, RightWay)) {
+        UE_LOG(LogTemp, Warning, TEXT("TryGetMergedSideWayに失敗(%s)"), *GetTargetTransName());
         return false;
     }
 
@@ -564,6 +565,7 @@ bool URnRoad::TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType BorderSide, fl
         Position = CenterWay->GetAdvancedPointFromFront(BorderOffset, StartIndex, EndIndex);
     }
     else {
+        UE_LOG(LogTemp, Warning, TEXT("InValid BorderSide(%s)"), *GetTargetTransName());
         return false;
     }
 
@@ -574,17 +576,20 @@ bool URnRoad::TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType BorderSide, fl
 
     TTuple<float, FVector> LeftIntersection, RightIntersection;
     if (!LeftWay->LineString->TryGetNearestIntersectionBy2D(Ray, LeftIntersection)) {
+        UE_LOG(LogTemp, Warning, TEXT("LeftWayの切断に失敗(%s)"), *GetTargetTransName());
         return false;
     }
 
     if (!RightWay->LineString->TryGetNearestIntersectionBy2D(Ray, RightIntersection)) {
+        UE_LOG(LogTemp, Warning, TEXT("RightWayの切断に失敗(%s)"), *GetTargetTransName());
         return false;
     }
 
     FVector DirectionNormalized = (LeftIntersection.Value - Ray.Origin).GetSafeNormal();
+    auto Padding = 20.f * FPLATEAURnDef::Meter2Unit;
     OutSegment = FLineSegment3D(
-        LeftIntersection.Value + DirectionNormalized * 20.f * FPLATEAURnDef::Meter2Unit,
-        RightIntersection.Value - DirectionNormalized * 20.f * FPLATEAURnDef::Meter2Unit);
+        LeftIntersection.Value + DirectionNormalized * Padding,
+        RightIntersection.Value - DirectionNormalized * Padding);
 
     return true;
 }

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment2D.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment2D.h
@@ -34,7 +34,7 @@ struct PLATEAURUNTIME_API FLineSegment2D {
         const FVector2D& Origin,
         const FVector2D& Direction,
         FVector2D& OutIntersection,
-        float& OutLineLength,
+        float& OutLineOffset,
         float& OutSegmentT) const;
     float GetDistance(const FLineSegment2D& Other) const;
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment2D.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment2D.h
@@ -29,13 +29,13 @@ struct PLATEAURUNTIME_API FLineSegment2D {
     bool TrySegmentIntersection(const FLineSegment2D& Other, FVector2D& OutIntersection) const;
     bool TrySegmentIntersection(const FLineSegment2D& Other) const;
 
-    bool TryHalfLineIntersection(const FVector2D& Origin, const FVector2D& Dir, FVector2D& OutIntersection, float& OutT1, float& OutT2) const;
+    bool TryHalfLineIntersection(const FVector2D& Origin, const FVector2D& Dir, FVector2D& OutIntersection, float& OutHalfLineOffset, float& OutSegmentT) const;
     bool TryLineIntersection(
         const FVector2D& Origin,
         const FVector2D& Direction,
         FVector2D& OutIntersection,
-        float& OutT1,
-        float& OutT2) const;
+        float& OutLineLength,
+        float& OutSegmentT) const;
     float GetDistance(const FLineSegment2D& Other) const;
 
     // Pointが線分の左側にあれば1, 右側にあれば-1, 線分上にあれば0を返す

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment3D.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment3D.h
@@ -23,7 +23,7 @@ public:
     FVector GetNearestPoint(const FVector& Point, float& OutDistanceFromStart) const;
 
     bool TryLineIntersectionBy2D(const FVector& Origin, const FVector& Dir, EAxisPlane Plane,
-        float NormalTolerance, FVector& OutIntersection, float& OutT1, float& OutT2) const;
+        float NormalTolerance, FVector& OutIntersection, float& OutLineLength, float& OutSegmentT) const;
 
     bool TryHalfLineIntersectionBy2D(const FVector& Origin, const FVector& Dir, EAxisPlane Plane,
         float NormalTolerance, FVector& OutIntersection, float& OutT1, float& OutT2) const;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment3D.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineSegment3D.h
@@ -23,7 +23,7 @@ public:
     FVector GetNearestPoint(const FVector& Point, float& OutDistanceFromStart) const;
 
     bool TryLineIntersectionBy2D(const FVector& Origin, const FVector& Dir, EAxisPlane Plane,
-        float NormalTolerance, FVector& OutIntersection, float& OutLineLength, float& OutSegmentT) const;
+        float NormalTolerance, FVector& OutIntersection, float& OutLineOffset, float& OutSegmentT) const;
 
     bool TryHalfLineIntersectionBy2D(const FVector& Origin, const FVector& Dir, EAxisPlane Plane,
         float NormalTolerance, FVector& OutIntersection, float& OutT1, float& OutT2) const;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineUtil.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineUtil.h
@@ -54,13 +54,13 @@ public:
         FVector2D& Intersection, float& T1, float& T2);
 
     UFUNCTION(BlueprintCallable)
-    static bool LineIntersection(const FRay2D& rayA, const FRay2D& rayB, FVector2D& intersection, float& t1, float& t2);
+    static bool LineIntersection(const FRay2D& rayA, const FRay2D& rayB, FVector2D& OutIntersection, float& OutRayAOffset, float& OutRayBOffset);
 
     UFUNCTION(BlueprintCallable)
     static bool HalfLineSegmentIntersection(const FRay2D& HalfLine, const FVector2D& P1, const FVector2D& P2,
-        FVector2D& Intersection, float& T1, float& T2);
+        FVector2D& OutIntersection, float& OutHalfLineOffset, float& OutSegmentT);
 
-    static bool LineSegmentIntersection(const FRay2D& line, FVector2D p1, FVector2D p2, FVector2D& Intersection, float& T1, float& T2);
+    static bool LineSegmentIntersection(const FRay2D& line, FVector2D p1, FVector2D p2, FVector2D& Intersection, float& OutLineLength, float& OutSegmentT);
     static bool SegmentIntersection(const FVector2D& S1St, const FVector2D& S1En,
                                     const FVector2D& S2St, const FVector2D& S2En,
                                     FVector2D& OutIntersection, float& OutT1, float& OutT2);

--- a/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
@@ -159,5 +159,3 @@ template<class T>
 inline TRnRef_T<T> RnFrom(TObjectPtr<T> Ptr) {
     return TPLATEAURnRef<T>::From(Ptr);
 }
-
-#define PLATEAU_RN_DETAIL_LOG

--- a/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
@@ -159,3 +159,5 @@ template<class T>
 inline TRnRef_T<T> RnFrom(TObjectPtr<T> Ptr) {
     return TPLATEAURnRef<T>::From(Ptr);
 }
+
+#define PLATEAU_RN_DETAIL_LOG


### PR DESCRIPTION
## 実装内容
交差点の停止線をずらす処理の失敗が多くなるバグ修正。
FLineSegment3D::TryLineIntersectionBy2Dで3次元の線を2Dに射影したうえでの交点を出した後、Up成分を計算するときに使う値が逆だったのを修正。

LineUtilの交点チェックの引数の名前をT1,T2などからわかりやすいものに変更

## 動作確認
道路構造を作成したときに、明らかに大きな道路で交差点の停止線をずらす処理がスキップされていないかチェックする


## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
