### PR TITLE
Feature/road network build 13

### DIFF
--- a/Source/PLATEAURuntime/Private/RoadNetwork/CityObject/SubDividedCityObject.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/CityObject/SubDividedCityObject.cpp
@@ -307,18 +307,66 @@ TSharedPtr<FSubDividedCityObject> FSubDividedCityObject::DeepCopy()
     return Result;
 }
 
+
 ERRoadTypeMask FSubDividedCityObject::GetRoadTypeFromCityObject(const FPLATEAUCityObject& CityObject)
 {
     auto Ret = ERRoadTypeMask::Empty;
 
     // LOD3からチェックする
     auto& AttrMap = CityObject.Attributes.AttributeMap;
+
+    static const TMap<FString, ERRoadTypeMask> FunctionValue2RoadType = []() -> TMap<FString, ERRoadTypeMask>
+    {
+        TMap<FString, ERRoadTypeMask> Map;
+        Map.Add(TEXT("車道部"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("車道交差部"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("非常駐車帯"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("側帯"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("路肩"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("停車帯"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("乗合自動車停車所"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("分離帯"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("路面電車停車所"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("自動車駐車場"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("島"), ERRoadTypeMask::Median);
+        Map.Add(TEXT("交通島"), ERRoadTypeMask::Median);
+        Map.Add(TEXT("中央帯"), ERRoadTypeMask::Median);
+        Map.Add(TEXT("自転車道"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("歩道"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("歩道部"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("自転車歩行者道"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("植栽"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("植樹帯"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("植樹ます"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("歩道部の段差"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("自転車駐車場"), ERRoadTypeMask::SideWalk);
+        Map.Add(TEXT("車線"), ERRoadTypeMask::Lane);
+        Map.Add(TEXT("すりつけ区間"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("踏切道"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("副道"), ERRoadTypeMask::Road);
+        // 不明なものは一旦Roadに
+        Map.Add(TEXT("軌道敷"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("待避所"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("軌道中心線"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("軌道"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("軌きょう"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("軌間"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("レール"), ERRoadTypeMask::Road);
+        Map.Add(TEXT("道床"), ERRoadTypeMask::Road);
+        return Map;
+    }();
+
+    if ( EnumHasAnyFlags (CityObject.Type, EPLATEAUCityObjectsType::COT_Road))
+    {
+        Ret |= ERRoadTypeMask::Road;
+    }
+
     if(auto TranFunc = AttrMap.Find("tran:function"))
     {
         auto&& Str = TranFunc->StringValue;
-        if(Str == TEXT("車道部") || Str == TEXT("車道交差部"))
-        {
-            Ret |= ERRoadTypeMask::Road;
+
+        if (const auto V = FunctionValue2RoadType.Find(Str)) {
+            Ret |= *V;
         }
 
         if (Str == TEXT("歩道部")) {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineUtil.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/GeoGraph/LineUtil.cpp
@@ -2,22 +2,6 @@
 
 #include "RoadNetwork/Util/PLATEAUVector2DEx.h"
 
-FLine::FLine(const FVector& InP0, const FVector& InP1)
-    : P0(InP0), P1(InP1) {
-}
-
-float FLine::GetSqrMag() const {
-    return (P0 - P1).SizeSquared();
-}
-
-float FLine::GetMag() const {
-    return (P0 - P1).Size();
-}
-
-FVector FLine::GetDirectionA2B() const {
-    return (P1 - P0).GetSafeNormal();
-}
-
 bool FRay2D::CalcIntersection(const FRay2D& other, FVector2D& intersection, float& t1, float& t2) const
 {
     auto ret = FLineUtil::LineIntersection(*this, other, intersection,  t1, t2);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/PLATEAURnDef.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/PLATEAURnDef.cpp
@@ -31,3 +31,13 @@ void FPLATEAURnDef::SetNewObjectWorld(UObject* World)
 inline FVector2D FPLATEAURnDef::To2D(const FVector& Vector) {
     return FAxisPlaneEx::ToVector2D(Vector, Plane);
 }
+
+FRay2D FPLATEAURnDef::To2D(const FRay& Ray)
+{
+    return FRay2D(To2D(Ray.Origin), To2D(Ray.Direction));
+}
+
+FVector FPLATEAURnDef::To3D(const FVector2D& Vector, float A)
+{
+    return FAxisPlaneEx::ToVector3D(Vector, Plane, A);
+}

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraph.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraph.cpp
@@ -524,5 +524,11 @@ ERRoadTypeMask URFaceGroup::GetRoadTypes() const {
     return Result;
 }
 
+RGraphRef_t<URFaceGroup> URFaceGroup::CreateFaceGroup(RGraphRef_t<URGraph> Graph,
+    UPLATEAUCityObjectGroup* CityObjectGroup, const TArray<RGraphRef_t<URFace>>& Faces)
+{
+    return RGraphNew<URFaceGroup>(Graph, CityObjectGroup, Faces);
+}
+
 constexpr auto SIZE = sizeof(UObject);
 constexpr auto OFFSET = sizeof(FVector);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphFactory.cpp
@@ -163,6 +163,12 @@ RGraphRef_t<URGraph> FRGraphFactoryEx::CreateGraph(const FRGraphFactory& Factory
         FRGraphEx::SeparateFaces(Graph);
     }
 
+    if (Factory.bOptRemoveIsolatedEdgeFromFace) {
+        FRGraphEx::RemoveIsolatedEdgeFromFace(Graph);
+    }
+
+    if (Factory.bOptModifySideWalkShape)
+        FRGraphEx::ModifySideWalkShape(Graph);
 
     return Graph;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
@@ -238,6 +238,12 @@ FRnModelDrawIntersectionOption::FRnModelDrawIntersectionOption()
     }
 }
 
+FPLATEAURnModelDrawerDebug::FPLATEAURnModelDrawerDebug()
+{
+    MedianLaneOption.bVisible = false;
+    MedianLaneOption.ShowCenterWay.Color = FLinearColor::Yellow;
+}
+
 //
 //bool FRnModelDrawWayOption::DrawImpl(RnModelDrawWork& work, URnWay& way)
 //{
@@ -373,11 +379,15 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
             virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override
             {
                 Lane L(Work.Self->LaneOption);
+                Lane Median(Work.Self->MedianLaneOption);
                 for (auto i = 0; i < Self.MainLanes.Num(); ++i) {
                     if (Option.ShowLaneIndex >= 0 && Option.ShowLaneIndex != i)
                         continue;
                     L.Draw(Work, Self.MainLanes[i], Work.visibleType);
                 }
+
+                if (Self.MedianLane)
+                    Median.Draw(Work, Self.MedianLane, Work.visibleType);
 
                 
 
@@ -497,7 +507,6 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
     private:
         virtual bool DrawImpl(RnModelDrawWork& Work, URnIntersection& Self) override
         {
-            Lane L(Work.Self->LaneOption);
             Way Border(Option.ShowBorderEdge);
             Way NonBorder(Option.ShowNonBorderEdge);
 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -359,7 +359,7 @@ void URnModel::MergeRoadGroup()
     }
 }
 
-void URnModel::SplitLaneByWidth(float RoadWidthMeter, bool rebuildTrack, TArray<FString>& failedRoads)
+void URnModel::SplitLaneByWidth(float RoadWidthMeter, bool rebuildTrack, TArray<FString>& failedRoads, TFunction<bool(URnRoadGroup*)> IsLaneSplitTarget)
 {
     failedRoads.Reset();
     TSet<TRnRef_T<URnRoad>> visitedRoads;
@@ -384,6 +384,10 @@ void URnModel::SplitLaneByWidth(float RoadWidthMeter, bool rebuildTrack, TArray<
 
             if (RoadGroup->Roads.ContainsByPredicate([](TRnRef_T<URnRoad> l) { return l->MainLanes[0]->HasBothBorder() == false; }))
                 continue;
+
+            if (IsLaneSplitTarget(RoadGroup) == false)
+                continue;
+
             auto&& leftCount = RoadGroup->GetLeftLaneCount();
             auto&& rightCount = RoadGroup->GetRightLaneCount();
             // すでにレーンが分かれている場合、左右で独立して分割を行う

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -673,13 +673,13 @@ void URnRoadGroup::SetLaneCountWithMedian(int32 LeftCount, int32 RightCount, flo
         auto Road = (Roads)[i];
         auto Lanes = AfterLanes[Road];
 
-        if (i == Roads.Num() - 1) 
+        if (i == Roads.Num() - 1 && NextIntersection)
         {
             NextIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select( Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
             NewNextBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
         }
 
-        if (i == 0) {
+        if (i == 0 && PrevIntersection) {
             PrevIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
             NewPrevBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
         }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURay2DEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURay2DEx.cpp
@@ -1,0 +1,11 @@
+// Plugins/PLATEAU-SDK-for-Unreal/Source/PLATEAURuntime/Private/RoadNetwork/Util/Vector2Ex.cpp
+#include "RoadNetwork/Util/PLATEAURay2DEx.h"
+
+#include "RoadNetwork/GeoGraph/LineUtil.h"
+#include "RoadNetwork/Util/PLATEAUVector2DEx.h"
+
+struct FRay2D;
+
+inline bool FPLATEAURay2DEx::IsPointOnLeftSide(const FRay2D& Self, const FVector2D Point) {
+    return FPLATEAUVector2DEx::IsPointOnLeftSide(Self.Direction, Point - Self.Origin);
+}

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
@@ -118,7 +118,7 @@ FPLATEAURnEx::FBorderEdgesResult FPLATEAURnEx::FindBorderEdges(const TArray<FVec
             if (List.Num() <= 4) return true;
             float Area1 = FGeoGraph2D::CalcPolygonArea(List);
             float Area2 = FGeoGraph2D::CalcPolygonArea(Verts);
-            return Area1 / Area2 < 0.7f;
+            return Area1 / Area2 < 0.6f;
         }
     );
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Factory/RoadNetworkFactory.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Factory/RoadNetworkFactory.h
@@ -80,6 +80,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU")
     bool bBuildTracks = true;
 
+    // LOD3.1以上のLane情報を見る
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU")
+    bool bCheckLane = true;
+
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU")
     FRGraphFactory GraphFactory;
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineUtil.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/LineUtil.h
@@ -4,27 +4,6 @@
 #include "LineUtil.generated.h"
 
 USTRUCT(BlueprintType)
-struct PLATEAURUNTIME_API FLine {
-    GENERATED_BODY()
-
-    FLine(){}
-    FLine(const FVector& InP0, const FVector& InP1);
-
-    UPROPERTY()
-    FVector P0;
-
-    UPROPERTY()
-    FVector P1;
-
-    float GetSqrMag() const;
-    float GetMag() const;
-    FVector GetDirectionA2B() const;
-    FVector GetDirectionB2A() const { return (P0 - P1).GetSafeNormal(); }
-    FVector GetVecA2B() const { return (P1 - P0); }
-    FVector GetVecB2A() const { return (P0 - P1); }
-};
-
-USTRUCT(BlueprintType)
 struct PLATEAURUNTIME_API FRay2D {
     GENERATED_BODY()
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
@@ -4,6 +4,7 @@
 #include "Math/Vector.h"
 #include "Containers/Array.h"
 #include "GeoGraph/AxisPlane.h"
+#include "GeoGraph/LineUtil.h"
 #include "PLATEAURnDef.generated.h"
 class UObject;
 UENUM(BlueprintType)
@@ -105,6 +106,9 @@ public:
 
     static FVector2D To2D(const FVector& Vector);
 
+    static FRay2D To2D(const FRay& Ray);
+
+    static FVector To3D(const FVector2D& Vector, float A = 0.f);
 private:
     static inline UObject* NewObjectWorld = nullptr;
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraph.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraph.h
@@ -194,6 +194,8 @@ public:
 
     ERRoadTypeMask GetRoadTypes() const;
 
+
+    static RGraphRef_t<URFaceGroup> CreateFaceGroup(RGraphRef_t<URGraph> Graph, UPLATEAUCityObjectGroup* CityObjectGroup, const TArray<RGraphRef_t<URFace>>& Faces);
 private:
     TSet<RGraphRef_t<URFace>> Faces;
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphDef.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphDef.h
@@ -2,36 +2,47 @@
 // ☀
 #include "CoreMinimal.h"
 
-// グラフ構造用
+/**
+ * 道路タイプ
+ */
 UENUM(meta = (Bitflags, UseEnumValuesAsMaskValuesInEditor = "true"))
 enum class ERRoadTypeMask : uint8 {
-    // 何もなし
-    Empty = 0 UMETA(Hidden),
+    /** 何もなし */
+    Empty = 0 UMETA(DisplayName = "Empty"),
 
-    // 車道
-    Road = 1 << 0,
+    /** 不正な値(今後要素が増えると後ろに追加する必要があるので最初に定義する) */
+    Undefined = 1 << 0 UMETA(DisplayName = "Undefined"),
 
-    // 歩道
-    SideWalk = 1 << 1,
+    /** 車道 */
+    Road = 1 << 1 UMETA(DisplayName = "Road"),
 
-    // 中央分離帯
-    Median = 1 << 2,
+    /** 歩道 */
+    SideWalk = 1 << 2 UMETA(DisplayName = "SideWalk"),
 
-    // 高速道路
-    HighWay = 1 << 3,
+    /** 中央分離帯 */
+    Median = 1 << 3 UMETA(DisplayName = "Median"),
 
-    // 不正な値
-    Undefined = 1 << 4,
+    /** 高速道路 */
+    HighWay = 1 << 4 UMETA(DisplayName = "HighWay"),
 
-    // 全ての値
-    //All = ~0
+    /** 車線. Lod3.1以上だとこれが車線を表す */
+    Lane = 1 << 5 UMETA(DisplayName = "Lane"),
+
+    /** 全ての値 */
+    All = (Undefined | Road | SideWalk | Median | HighWay | Lane) UMETA(DisplayName = "All")
 };
 ENUM_CLASS_FLAGS(ERRoadTypeMask);
 
 class FRRoadTypeMaskEx {
 public:
     static ERRoadTypeMask All() {
-        return (ERRoadTypeMask)(((int32)ERRoadTypeMask::Undefined << 1) - 1);
+        return
+        ERRoadTypeMask::Undefined
+        | ERRoadTypeMask::Road
+        | ERRoadTypeMask::SideWalk
+        | ERRoadTypeMask::Median
+        | ERRoadTypeMask::HighWay
+        | ERRoadTypeMask::Lane;
     }
 
     // 車道部分
@@ -52,6 +63,11 @@ public:
     // 中央分離帯
     static bool IsMedian(ERRoadTypeMask Self) {
         return EnumHasAnyFlags(Self, ERRoadTypeMask::Median);
+    }
+
+    // 中央分離帯
+    static bool IsLane(ERRoadTypeMask Self) {
+        return EnumHasAnyFlags(Self, ERRoadTypeMask::Lane);
     }
 
     // selfがflagのどれかを持っているかどうか

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphEx.h
@@ -44,6 +44,9 @@ public:
     // Verticesの隣接情報に基づくので生成できない場合もある
     static bool OutlineVertex2Edge(const TArray<RGraphRef_t<URVertex>>& Vertices, TArray<RGraphRef_t<UREdge>>& OutlineEdges);
 
+    /*
+     * 歩道情報を作成
+     */
     static bool CreateSideWalk(
         RGraphRef_t<URFace> Face
         , TArray<RGraphRef_t<UREdge>>& OutsideEdges
@@ -52,6 +55,17 @@ public:
         , TArray<RGraphRef_t<UREdge>>& EndEdges
     );
 
+    /*
+     * 歩道情報を作成
+     */
+    static bool CreateSideWalk(
+        RGraphRef_t<URFaceGroup> Face
+        , TArray<RGraphRef_t<UREdge>>& OutsideEdges
+        , TArray<RGraphRef_t<UREdge>>& InsideEdges
+        , TArray<RGraphRef_t<UREdge>>& StartEdges
+        , TArray<RGraphRef_t<UREdge>>& EndEdges
+        , TSet<UPLATEAUCityObjectGroup*> NeighborCityObjectGroupsFilter
+    );
     // EdgesをKeyでグループ化したもの
     template<typename TKey>
     using FOutlineBorderGroup = FPLATEAURnEx::FKeyEdgeGroup<TKey, RGraphRef_t<UREdge>>;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphEx.h
@@ -66,6 +66,17 @@ public:
         , TArray<RGraphRef_t<UREdge>>& EndEdges
         , TSet<UPLATEAUCityObjectGroup*> NeighborCityObjectGroupsFilter
     );
+
+    /*
+     * 歩道のうちOutSideがない歩道に対して微小な辺を追加する
+     */
+    static void ModifySideWalkShape(RGraphRef_t<URGraph> Self);
+
+    /*
+     * 歩道のうちOutSideがない歩道に対して微小な辺を追加する
+     */
+    static void ModifySideWalkShape(RGraphRef_t<URFace> Self);
+
     // EdgesをKeyでグループ化したもの
     template<typename TKey>
     using FOutlineBorderGroup = FPLATEAURnEx::FKeyEdgeGroup<TKey, RGraphRef_t<UREdge>>;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphFactory.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphFactory.h
@@ -48,6 +48,9 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
     bool bOptSeparateFaces = true;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
+    bool bOptModifySideWalkShape = true;
 };
 
 struct FRGraphFactoryEx

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphFactory.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphFactory.h
@@ -20,10 +20,10 @@ public:
     bool bUseCityObjectOutline = true;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
-    float MergeCellSize = 0.5f;
+    float MergeCellSize = 0.2f;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
-    int32 MergeCellLength = 4;
+    int32 MergeCellLength = 2;
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
     float RemoveMidPointTolerance = 0.3f;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
@@ -247,8 +247,9 @@ struct PLATEAURUNTIME_API FPLATEAURnModelDrawerDebug {
     GENERATED_BODY()
 
 public:
+    FPLATEAURnModelDrawerDebug();
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
-    bool bVisible = true;
+    bool bVisible = false;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     bool bShowInsideNormalMidPoint = false;
@@ -278,13 +279,16 @@ public:
     FRnModelDrawLaneOption LaneOption;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    FRnModelDrawLaneOption MedianLaneOption;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     FRnModelDrawSideWalkOption SideWalkOption;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug", Meta = (Bitmask, BitmaskEnum = ERnPartsTypeMask))
-    int32 ShowPartsType;
+    int32 ShowPartsType = 0;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
-    bool bShowOnlyTargets;
+    bool bShowOnlyTargets = false;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     TArray<FString> ShowTargetNames;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
@@ -5,6 +5,7 @@
 #include "RoadNetwork/PLATEAURnDef.h"
 #include "RoadNetwork/Util/PLATEAURnEx.h"
 #include "RnModel.generated.h"
+class URnRoadGroup;
 class URnRoad;
 class URnIntersection;
 class URnSideWalk;
@@ -137,7 +138,7 @@ public:
     void MergeRoadGroup();
 
     // roadWidthの道路幅を基準にレーンを分割する
-    void SplitLaneByWidth(float RoadWidth, bool rebuildTrack, TArray<FString>& failedRoads);
+    void SplitLaneByWidth(float RoadWidth, bool rebuildTrack, TArray<FString>& failedRoads, TFunction<bool(URnRoadGroup*)> IsLaneSplitTarget);
 
     // 不正チェック
     bool Check() const;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURay2DEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURay2DEx.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Math/Vector2D.h"
+#include "Math/Vector.h"
+#include "Kismet/KismetMathLibrary.h"
+// Plugins/PLATEAU-SDK-for-Unreal/Source/PLATEAURuntime/Private/RoadNetwork/Util/Vector2Ex.h
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FRay2D;
+
+class PLATEAURUNTIME_API FPLATEAURay2DEx
+{
+public:
+
+    // pointがselfの左側にあるかどうか
+    static bool IsPointOnLeftSide(const FRay2D& Self, FVector2D Point);
+};

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnLinq.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnLinq.h
@@ -59,6 +59,18 @@ public:
         return SelectWithIndexImpl<T, DstType>(Src, Forward<F>(Selector));
     }
 
+    // Linq.Where代わり
+    template<typename T, typename F>
+    static auto Where(const TSet<T>& Src, F&& Predicate) {
+        TArray<T> Result;
+        for (const auto& S : Src) {
+            if (Predicate(S)) {
+                Result.Add(S);
+            }
+        }
+        return Result;
+    }
+
     // Enumerable.Range代わり
     static TArray<int32> Range(int32 Start, int32 Count)
     {


### PR DESCRIPTION
## 関連リンク
https://synesthesias.atlassian.net/browse/PLTSDK3-258

## LOD3.1対応
### LOD3.1の都市モデルに対して車線情報を見る処理
1. CityObjectEx.functionValue2RoadTypeにつくば市のデータの値を使って歩道/道路などの対応関係を追加
2. RRoaTypeMaskにLane(車線を追加)
3. 道路構造を生成するときに, 境界線(Prev/Next)に接続しているLaneのメッシュの数で車線数を推定する処理を追加

### LOD3.1の歩道生成対応
LOD3.1は歩道が細かいサブメッシュに分解されているので、連結した歩道を一つにまとめる処理を追加
RoadNetworkFactory.csの873行目付近のif(AddSideWalk)の中で、個別のFaceを追加していたのをFaceGroup単位の外形を見て追加するように

### 動作確認
つくば市の54401006で確認しました。(さすがにすべての地域メッシュで確認はできていないので、ほかの地域メッシュで確認ても良いかと)

tran_a63dc150-cec1-4e3a-901d-1df8fcfc5eddのようにLaneを持つモデルの道路情報を確認する

![image](https://github.com/user-attachments/assets/ffd4321a-6810-48ed-baf1-adffd071ec39)

![image](https://github.com/user-attachments/assets/9a2bcb7b-7b97-4f07-9f05-7f7043a29676)

### 頂点結合のデフォルト値を変更
それ以上はデータがわを直してもらうとの事なので
セルサイズ 0.5 -> 0.2
マージするセル長 4 -> 2

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [x] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
