### PR TITLE
fix : GeoGraph2d.hがPLATEAURnExをincludeしていたのでCompare/Vector3ComparerをR…

### DIFF
--- a/Source/PLATEAURuntime/Private/RoadNetwork/PLATEAURnDef.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/PLATEAURnDef.cpp
@@ -28,6 +28,16 @@ void FPLATEAURnDef::SetNewObjectWorld(UObject* World)
     NewObjectWorld = World;
 }
 
-inline FVector2D FPLATEAURnDef::To2D(const FVector& Vector) {
+FVector2D FPLATEAURnDef::To2D(const FVector& Vector) {
     return FAxisPlaneEx::ToVector2D(Vector, Plane);
+}
+
+int32 FPLATEAURnDef::Vector3Comparer::operator()(const FVector& A, const FVector& B) const {
+    auto X = Compare(A.X, B.X);
+    if (X != 0)
+        return X;
+    auto Y = Compare(A.Y, B.Y);
+    if (Y != 0)
+        return Y;
+    return X = Compare(A.Z, B.Z);
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphEx.cpp
@@ -273,7 +273,7 @@ void FRGraphEx::InsertVertexInNearEdge(RGraphRef_t<URGraph> Graph, float Toleran
 
     auto&& Vertices = Graph->GetAllVertices().Array();
 
-    constexpr auto Comp = FPLATEAURnEx::Vector3Comparer();
+    constexpr auto Comp = FPLATEAURnDef::Vector3Comparer();
 
     auto Comparer = [&](const RGraphRef_t<URVertex>& A, const RGraphRef_t<URVertex>& B) {
         return Comp(A->Position, B->Position);
@@ -339,7 +339,7 @@ void FRGraphEx::InsertVerticesInEdgeIntersection(RGraphRef_t<URGraph> Graph, flo
 
     auto&& Vertices = Graph->GetAllVertices().Array();
 
-    constexpr auto Comp = FPLATEAURnEx::Vector3Comparer();
+    constexpr auto Comp = FPLATEAURnDef::Vector3Comparer();
 
     auto Comparer = [&](const RGraphRef_t<URVertex>& A, const RGraphRef_t<URVertex>& B) {
         return Comp(A->Position, B->Position);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Util/PLATEAURnEx.cpp
@@ -10,17 +10,6 @@
 #include "RoadNetwork/Structure/RnSideWalk.h"
 #include "RoadNetwork/Util/PLATEAURnLinq.h"
 
-int32 FPLATEAURnEx::Vector3Comparer::operator()(const FVector& A, const FVector& B) const
-{
-    auto X = Compare(A.X, B.X);
-    if (X != 0)
-        return X;
-    auto Y = Compare(A.Y, B.Y);
-    if (Y != 0)
-        return Y;
-    return X = Compare(A.Z, B.Z);
-}
-
 void FPLATEAURnEx::ReplaceLane(TArray<TRnRef_T<URnLane>>& Self, TRnRef_T<URnLane> Before, TRnRef_T<URnLane> After) {
     Replace(Self, Before, After);
 }

--- a/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/GeoGraph2d.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/GeoGraph/GeoGraph2d.h
@@ -5,8 +5,8 @@
 #include "Math/Vector2D.h"
 #include "Math/Vector.h"
 #include "Containers/Array.h"
+
 #include "RoadNetwork/PLATEAURnDef.h"
-#include "RoadNetwork/Util/PLATEAURnEx.h"
 #include "RoadNetwork/Util/PLATEAUVector2DEx.h"
 
 class PLATEAURUNTIME_API FGeoGraph2D {
@@ -416,14 +416,16 @@ FGeoGraph2D::FComputeOutlineResult<T> FGeoGraph2D::ComputeOutline(
         return FComputeOutlineResult<T>(false, hasCrossing, ret);
         };
 
+
+
     auto leftSearch = Search(
         Keys[0]
         , -FVector2D::UnitY()
         , [](EvalValue A, EvalValue B) 
         {
-            auto x = -FPLATEAURnEx::Compare(A.Angle, B.Angle);
+            auto x = -FPLATEAURnDef::Compare(A.Angle, B.Angle);
             if(x == 0)
-                x = FPLATEAURnEx::Compare(A.SqrLen, B.SqrLen);
+                x = FPLATEAURnDef::Compare(A.SqrLen, B.SqrLen);
             return x;
         });
     // 見つかったらそれでおしまい
@@ -436,9 +438,9 @@ FGeoGraph2D::FComputeOutlineResult<T> FGeoGraph2D::ComputeOutline(
         Keys[0]
         , FVector2D::UnitY()
         , [](EvalValue A, EvalValue B) {
-            auto x = FPLATEAURnEx::Compare(A.Angle, B.Angle);
+            auto x = FPLATEAURnDef::Compare(A.Angle, B.Angle);
             if (x == 0)
-                x = FPLATEAURnEx::Compare(A.SqrLen, B.SqrLen);
+                x = FPLATEAURnDef::Compare(A.SqrLen, B.SqrLen);
             return x;
         });
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/PLATEAURnDef.h
@@ -105,6 +105,25 @@ public:
 
     static FVector2D To2D(const FVector& Vector);
 
+    // A < B なら-1, A > B なら1, A == B なら0
+    template<typename T>
+    static int32 Compare(T A, T B) {
+        if (A < B)
+            return -1;
+        if (A > B)
+            return 1;
+        return 0;
+    }
+
+    /*
+     * FVectorのComparer. X, Y, Zの順で比較する
+     */
+    class Vector3Comparer {
+    public:
+        int32 operator()(const FVector& A, const FVector& B) const;
+    };
+
+
 private:
     static inline UObject* NewObjectWorld = nullptr;
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Util/PLATEAURnEx.h
@@ -22,13 +22,6 @@ class URnLane;
 
 struct FPLATEAURnEx
 {
-
-    class Vector3Comparer {
-    public:
-        int32 operator()(const FVector& A, const FVector& B) const;
-    };
-
-
     class FLineCrossPointResult {
     public:
         class FTargetLineInfo {
@@ -105,17 +98,6 @@ public:
     static FLineCrossPointResult GetLaneCrossPoints(TRnRef_T<URnRoad> Road,  const FLineSegment3D& LineSegment);
 
 public:
-    template<typename T>
-    static int32 Compare(T A, T B)
-    {
-        if (A < B)
-            return -1;
-        if (A > B)
-            return 1;
-        return 0;
-    }
-
-
     // ParentにChildを追加する
     // ActorにAddInstanceComponentをして, ChildをParentにアタッチする
     static void AddChildInstanceComponent(AActor* Actor, USceneComponent* Parent, USceneComponent* Child, FAttachmentTransformRules TransformRule = FAttachmentTransformRules::KeepRelativeTransform);


### PR DESCRIPTION

## 関連リンク
https://synesthesias.slack.com/archives/C0261M64C15/p1739840647144039


## 実装内容
GeoGraph2D.hでPLATEAURnEx.hが循環参照になっていたようだったので関数を移動

## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [x] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

