### PR TITLE
update : SubDividedCityObjectFactory.cppで生成対象のチェックを行うように

### DIFF
--- a/Source/PLATEAURuntime/Private/RoadNetwork/CityObject/SubDividedCityObjectFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/CityObject/SubDividedCityObjectFactory.cpp
@@ -4,6 +4,7 @@
 #include "PLATEAUMeshExporter.h"
 #include "CityGML/PLATEAUCityObject.h"
 #include "Reconstruct/PLATEAUModelReconstruct.h"
+#include "RoadNetwork/Factory/RoadNetworkFactory.h"
 #include "Util/PLATEAUReconstructUtil.h"
 
 namespace
@@ -36,9 +37,10 @@ FSubDividedCityObjectFactory::ConvertCityObjectsAsync(
 
     for (auto CityObjectGroup : CityObjectGroups) 
     {
-        // 見えていないものはスキップ
-        if (CityObjectGroup->IsVisible() == false)
+        // 生成対象チェック
+        if (FRoadNetworkFactoryEx::IsConvertTarget(CityObjectGroup) == false)
             continue;
+
         TArray<UPLATEAUCityObjectGroup*> Tmp;
         Tmp.Add(CityObjectGroup);
         auto model = Loader.ConvertModelForReconstruct(Tmp);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Factory/RoadNetworkFactory.cpp
@@ -858,6 +858,23 @@ void FRoadNetworkFactoryEx::CreateRnModel(const FRoadNetworkFactory& Self, APLAT
     auto res = CreateRoadNetwork(Self, Actor, DestActor, CityObjectGroups);
 }
 
+bool FRoadNetworkFactoryEx::IsConvertTarget(UPLATEAUCityObjectGroup* Target)
+{
+    if (!Target)
+        return false;
+
+    // 非表示オブジェクトは無視
+    if (Target->IsVisible() == false)
+        return false;
+
+    const auto RootCityObjects = Target->GetAllRootCityObjects();
+    // 少なくとも一つはCOT_Roadを含める必要がある
+    return RootCityObjects.ContainsByPredicate([](const FPLATEAUCityObject& A) 
+        {
+        return A.Type == EPLATEAUCityObjectsType::COT_Road;
+        });
+}
+
 TRnRef_T<URnModel> FRoadNetworkFactoryEx::CreateRoadNetwork(
     const FRoadNetworkFactory& Self
     , APLATEAUInstancedCityModel* TargetCityModel

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Factory/RoadNetworkFactory.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Factory/RoadNetworkFactory.h
@@ -104,6 +104,8 @@ struct FRoadNetworkFactoryEx
 
     static void CreateRnModel(const FRoadNetworkFactory& Self, APLATEAUInstancedCityModel* Actor, APLATEAURnStructureModel* DestActor);
 
+    // Targetが生成対象かどうか
+    static bool IsConvertTarget(UPLATEAUCityObjectGroup* Target);
 private:
 
     static TRnRef_T<URnModel> CreateRoadNetwork(


### PR DESCRIPTION
## 関連リンク
https://synesthesias.slack.com/archives/C0261M64C15/p1739892956809099

## 実装内容
C#側でSubDividedCityObject生成するときにdemなどをはじくための処理がUE側に移植されていなかったので移植

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## 動作確認
## その他
