### PR TITLE
高さ合わせしてからUnreal Engineを再起動すると土地のテクスチャが剥がれるバグ

### DIFF
--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUMeshLoaderForLandscapeMesh.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUMeshLoaderForLandscapeMesh.cpp
@@ -108,8 +108,14 @@ UStaticMeshComponent* FPLATEAUMeshLoaderForLandscapeMesh::GetStaticMeshComponent
 
 UMaterialInterface* FPLATEAUMeshLoaderForLandscapeMesh::GetMaterialForSubMesh(const FSubMeshMaterialSet& SubMeshValue, UStaticMeshComponent* Component,
     const FLoadInputData& LoadInputData, UTexture2D* Texture, FNodeHierarchy NodeHier) {
-    if (ReplaceMaterial != nullptr)
-        return ReplaceMaterial;
+    if (ReplaceMaterial != nullptr) {
+        //Dynamic Material 再生成・Texture再設定 (レベル保存時に消えてしまうため）
+        auto DynMaterial = UMaterialInstanceDynamic::Create(ReplaceMaterial->GetMaterial(), Component);
+        UTexture* ReferencedTexture = nullptr;
+        ReplaceMaterial->GetTextureParameterValue(TEXT("Texture"), ReferencedTexture);
+        DynMaterial->SetTextureParameterValue("Texture", ReferencedTexture);
+        return DynMaterial;
+    }
     return FPLATEAUMeshLoader::GetMaterialForSubMesh(SubMeshValue, Component, LoadInputData, Texture, NodeHier);
 }
 

--- a/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUMeshLoaderForLandscapeMesh.cpp
+++ b/Source/PLATEAURuntime/Private/Reconstruct/PLATEAUMeshLoaderForLandscapeMesh.cpp
@@ -11,6 +11,9 @@
 #include "StaticMeshOperations.h"
 #include "StaticMeshAttributes.h"
 #include "plateau/height_map_generator/heightmap_mesh_generator.h"
+#include "MathUtil.h"
+#include "Materials/Material.h"
+#include "Materials/MaterialInstanceDynamic.h"
 
 FPLATEAUMeshLoaderForLandscapeMesh::FPLATEAUMeshLoaderForLandscapeMesh() {}
 


### PR DESCRIPTION
## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
平滑化メッシュ生成時にDynamicMaterialを再生成する

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## 動作確認
高さ合わせしてレベル保存する
Unreal Engineを再起動し保存したレベルを開く
土地のテクスチャがついていること

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
