### PR TITLE
Fix/road network same prev next

### DIFF
--- a/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUDirectionalArrowComposer.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUDirectionalArrowComposer.cpp
@@ -45,7 +45,7 @@ TArray<TObjectPtr<UStaticMeshComponent>> FPLATEAUDirectionalArrowComposer::Compo
 
             if (Lane->GetNextBorder())
             {
-                auto* Inter = Lane->GetIsReverse() ? PrevIntersection : NextIntersection;
+                auto* Inter = Lane->GetIsReversed() ? PrevIntersection : NextIntersection;
                 bool bIsSucceedPosition = false;
                 bool bIsSucceedAngle = false;
                 const auto Position = ArrowPosition(Lane, true, bIsSucceedPosition);
@@ -63,7 +63,7 @@ TArray<TObjectPtr<UStaticMeshComponent>> FPLATEAUDirectionalArrowComposer::Compo
 
             if (Lane->GetPrevBorder())
             {
-                auto* Inter = Lane->GetIsReverse() ? NextIntersection : PrevIntersection;
+                auto* Inter = Lane->GetIsReversed() ? NextIntersection : PrevIntersection;
                 bool bIsSucceedPosition = false;
                 bool bIsSucceedAngle = false;
                 const auto Position = ArrowPosition(Lane, false, bIsSucceedPosition);

--- a/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUMCCenterLine.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUMCCenterLine.cpp
@@ -70,9 +70,9 @@ float FPLATEAUIntersectionDistCalc::RoadLength(URnRoadBase* RoadBase) const
     if(RoadBase == nullptr) return 0.0f;
     auto Road = RoadBase->CastToRoad();
     if(Road == nullptr) return 0.0f;
-    if (Road->GetAllLanes().Num() > 0 && Road->GetAllLanes()[0]->GetRightWay() != nullptr)
+    if (Road->GetMainLanes().Num() > 0 && Road->GetMainLanes()[0]->GetRightWay() != nullptr)
     {
-        return Road->GetAllLanes()[0]->GetRightWay()->CalcLength();
+        return Road->GetMainLanes()[0]->GetRightWay()->CalcLength();
     }
     return 0.0f;
 }
@@ -87,7 +87,7 @@ bool UPLATEAUMCCenterLine::IsCenterLineYellow(float DistFromIntersection, float 
 
 EPLATEAUMarkedWayType UPLATEAUMCCenterLine::GetCenterLineTypeOfWidth(const URnRoad* Road) const
 {
-    const auto& CarLanes = Road->GetAllLanes();
+    const auto& CarLanes = Road->GetMainLanes();
     
     // 片側の道路幅からタイプを判定します
     float ReverseWidth = 0.0f;
@@ -95,7 +95,7 @@ EPLATEAUMarkedWayType UPLATEAUMCCenterLine::GetCenterLineTypeOfWidth(const URnRo
     
     for (const auto& Lane : CarLanes)
     {
-        if (Lane->GetIsReverse())
+        if (Lane->GetIsReversed())
             ReverseWidth += Lane->CalcWidth();
         else
             ForwardWidth += Lane->CalcWidth();
@@ -150,7 +150,7 @@ FPLATEAUMarkedWayList UPLATEAUMCCenterLine::ComposeFrom(const IPLATEAURrTarget* 
         if (!Road->IsValid())
             continue;
 
-        const auto& CarLanes = Road->GetAllLanes();
+        const auto& CarLanes = Road->GetMainLanes();
         const auto WidthType = GetCenterLineTypeOfWidth(Road);
         const FPLATEAUIntersectionDistCalc InterDistCalc(Road);
         const bool bMedianLaneExist = Road->GetMedianLane() != nullptr;
@@ -159,12 +159,12 @@ FPLATEAUMarkedWayList UPLATEAUMCCenterLine::ComposeFrom(const IPLATEAURrTarget* 
         {
             const auto& Lane = CarLanes[i];
             // 隣のレーンと進行方向が異なる場合、Rightwayはセンターラインです
-            bool bIsCenterLane = i < CarLanes.Num() - 1 && Lane->GetIsReverse() != CarLanes[i + 1]->GetIsReverse();
+            bool bIsCenterLane = i < CarLanes.Num() - 1 && Lane->GetIsReversed() != CarLanes[i + 1]->GetIsReversed();
             
             // 中央分離帯がある場合、センターラインは2つになるので、隣チェックを両方向で行います
             if (bMedianLaneExist)
             {
-                bIsCenterLane |= i >= 1 && Lane->GetIsReverse() != CarLanes[i - 1]->GetIsReverse();
+                bIsCenterLane |= i >= 1 && Lane->GetIsReversed() != CarLanes[i - 1]->GetIsReversed();
             }
 
             if (!bIsCenterLane)
@@ -214,7 +214,7 @@ FPLATEAUMarkedWayList UPLATEAUMCCenterLine::ComposeFrom(const IPLATEAURrTarget* 
                     Result.Add(FPLATEAUMarkedWay(
                         FPLATEAUMWLine(Points),
                         PrevInterType,
-                        Lane->GetIsReverse()
+                        Lane->GetIsReversed()
                     ));
 
                     // リセット
@@ -239,7 +239,7 @@ FPLATEAUMarkedWayList UPLATEAUMCCenterLine::ComposeFrom(const IPLATEAURrTarget* 
                 Result.Add(FPLATEAUMarkedWay(
                     FPLATEAUMWLine(Points),
                     PrevInterType,
-                    Lane->GetIsReverse()
+                    Lane->GetIsReversed()
                 ));
             }
 

--- a/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUMCLaneLine.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUMCLaneLine.cpp
@@ -15,7 +15,7 @@ FPLATEAUMarkedWayList UPLATEAUMCLaneLine::ComposeFrom(const IPLATEAURrTarget* Ta
         if (!Road->IsValid())
             continue;
 
-        const auto& CarLanes = Road->GetAllLanes();
+        const auto& CarLanes = Road->GetMainLanes();
         // 車道のうち、端でない（路側帯線でない）もののLeftWayは車線境界線です。
         for (int i = 1; i < CarLanes.Num() - 1; i++) { // 端を除くループ
             const auto& Lane = CarLanes[i];
@@ -25,7 +25,7 @@ FPLATEAUMarkedWayList UPLATEAUMCLaneLine::ComposeFrom(const IPLATEAURrTarget* Ta
             Result.Add(FPLATEAUMarkedWay(
                 FPLATEAUMWLine(Lane->GetLeftWay()->GetVertices()),
                 EPLATEAUMarkedWayType::LaneLine,
-                Lane->GetIsReverse()
+                Lane->GetIsReversed()
             ));
         }
     }

--- a/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUMCShoulderLine.cpp
+++ b/Source/PLATEAURuntime/Private/RoadAdjust/RoadMarking/PLATEAUMCShoulderLine.cpp
@@ -12,7 +12,7 @@ FPLATEAUMarkedWayList UPLATEAUMCShoulderLine::ComposeFrom(const IPLATEAURrTarget
         if (!Road->IsValid())
             continue;
 
-        const auto& CarLanes = Road->GetAllLanes();
+        const auto& CarLanes = Road->GetMainLanes();
         if (CarLanes.Num() == 0)
             continue;
 
@@ -25,7 +25,7 @@ FPLATEAUMarkedWayList UPLATEAUMCShoulderLine::ComposeFrom(const IPLATEAURrTarget
             Result.Add(FPLATEAUMarkedWay(
                 FPLATEAUMWLine(FirstLane->GetLeftWay()->GetVertices()),
                 EPLATEAUMarkedWayType::ShoulderLine,
-                FirstLane->GetIsReverse()
+                FirstLane->GetIsReversed()
             ));
         }
 
@@ -34,7 +34,7 @@ FPLATEAUMarkedWayList UPLATEAUMCShoulderLine::ComposeFrom(const IPLATEAURrTarget
             Result.Add(FPLATEAUMarkedWay(
                 FPLATEAUMWLine(LastLane->GetLeftWay()->GetVertices()),
                 EPLATEAUMarkedWayType::ShoulderLine,
-                LastLane->GetIsReverse()
+                LastLane->GetIsReversed()
             ));
         }
     }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/PLATEAURGraph.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/PLATEAURGraph.cpp
@@ -20,6 +20,7 @@ UPLATEAURGraph::UPLATEAURGraph() {
     RoadColor = FLinearColor::White;
     HighWayColor = FLinearColor::Blue;
     SideWalkColor = FLinearColor::Green;
+    MedianColor = FLinearColor::Yellow;
     UndefinedColor = FLinearColor::Red;
     VertexOption.bVisible = false;
     EdgeOption.ShowTypeMask = (int32)FRRoadTypeMaskEx::All();
@@ -31,6 +32,8 @@ FLinearColor UPLATEAURGraph::GetColor(ERRoadTypeMask RoadType) {
         return HighWayColor;
     if (FRRoadTypeMaskEx::IsSideWalk(RoadType))
         return SideWalkColor;
+    if (FRRoadTypeMaskEx::IsMedian(RoadType))
+        return MedianColor;
     if (FRRoadTypeMaskEx::IsRoad(RoadType))
         return RoadColor;
     return UndefinedColor;

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphEx.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphEx.cpp
@@ -1165,3 +1165,48 @@ void FRGraphEx::ModifySideWalkShape(RGraphRef_t<URFace> swFace) {
         }
     }
 }
+
+int32 FRGraphEx::FaceReduction(URGraph* Graph)
+{
+    int32 RemovedFaceCount = 0;
+
+    // キー: Face の Edge 数, 値: 該当する URFace* の配列
+    TMap<int32, TArray<URFace*>> FaceMap;
+
+    // Graph 内の全 Face を、Edge 数でグループ化する
+    for (URFace* Face : Graph->GetFaces()) {
+        int32 NumEdges = Face->GetEdges().Num();
+        FaceMap.FindOrAdd(NumEdges).Add(Face);
+    }
+
+    // グループ内の Face 同士で、同一の Edge 群かどうかをチェックする
+    for (auto& Pair : FaceMap) {
+        TArray<URFace*>& Faces = Pair.Value;
+        // インデックス i, j の組み合わせで比較
+        for (int32 i = 0; i < Faces.Num(); i++) {
+            URFace* Face1 = Faces[i];
+            for (int32 j = i + 1; j < Faces.Num(); j++) {
+                URFace* Face2 = Faces[j];
+                bool bAllContained = true;
+                // Face1 の全エッジが Face2 に含まれているかを確認する
+                for (UREdge* Edge : Face1->GetEdges()) {
+                    if (!Face2->GetEdges().Contains(Edge)) {
+                        bAllContained = false;
+                        break;
+                    }
+                }
+                // Face1 のすべての Edge が Face2 に含まれる場合、Face2 を Face1 にマージ
+                if (bAllContained) {
+                    if (Face2->TryMergeTo(Face1)) {
+                        Faces.RemoveAt(j);
+                        j--;
+                        RemovedFaceCount++;
+                    }
+                }
+            }
+        }
+    }
+
+    UE_LOG(LogTemp, Log, TEXT("MergeFaces: %d"), RemovedFaceCount);
+    return RemovedFaceCount;
+}

--- a/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphFactory.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/RGraph/RGraphFactory.cpp
@@ -167,8 +167,12 @@ RGraphRef_t<URGraph> FRGraphFactoryEx::CreateGraph(const FRGraphFactory& Factory
         FRGraphEx::RemoveIsolatedEdgeFromFace(Graph);
     }
 
-    if (Factory.bOptModifySideWalkShape)
+    if (Factory.bOptModifySideWalkShape) {
         FRGraphEx::ModifySideWalkShape(Graph);
+    }
 
+    if(Factory.bFaceReduction) {
+        FRGraphEx::FaceReduction(Graph);
+    }
     return Graph;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
@@ -238,6 +238,14 @@ FRnModelDrawIntersectionOption::FRnModelDrawIntersectionOption()
     }
 }
 
+FRnModelDrawSideWalkOption::FRnModelDrawSideWalkOption()
+{
+    ShowInsideWay.Color = FLinearColor::Red;
+    ShowOutsideWay.Color = FLinearColor::Blue;
+    ShowStartEdgeWay.Color = FLinearColor::Yellow;
+    ShowEndEdgeWay.Color = FLinearColor::Green;
+}
+
 FPLATEAURnModelDrawerDebug::FPLATEAURnModelDrawerDebug()
 {
     MedianLaneOption.bVisible = false;
@@ -277,50 +285,40 @@ FPLATEAURnModelDrawerDebug::FPLATEAURnModelDrawerDebug()
 //
 //    return true;
 //}
-void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
+
+namespace
 {
-    if (bVisible == false)
-        return;
-
-    if (!Model)
-        return;
-
-    struct Way : public FRnModelWayDrawer<FRnModelDrawWayOption>
-    {
-        Way(const FRnModelDrawWayOption& InOption)
-            : FRnModelWayDrawer(InOption)
-        {}
+    struct WayDrawer : public FRnModelWayDrawer<FRnModelDrawWayOption> {
+        WayDrawer(const FRnModelDrawWayOption& InOption)
+            : FRnModelWayDrawer(InOption) {
+        }
 
     private:
-        virtual bool DrawImpl(RnModelDrawWork& Work, URnWay& Self) override
-        {
+        virtual bool DrawImpl(RnModelDrawWork& Work, URnWay& Self) override {
             const auto Vertices = Self.GetVertices().ToArray();
             Work.DrawArrows(Vertices, false, Option.ArrowSize, FVector::UnitZ(), Option.Color);
             return true;
         }
     };
 
-    struct Lane : public FRnModelLaneDrawer<FRnModelDrawLaneOption>
-    {
-        Lane(const FRnModelDrawLaneOption& InOption)
+    struct LaneDrawer : public FRnModelLaneDrawer<FRnModelDrawLaneOption> {
+        LaneDrawer(const FRnModelDrawLaneOption& InOption)
             :FRnModelLaneDrawer(InOption) {
 
         }
     private:
-        virtual bool DrawImpl(RnModelDrawWork& Work, URnLane& Self) override
-        {
-            Way(Option.ShowLeftWay).Draw(Work, Self.GetLeftWay(), Work.visibleType);
-            Way(Option.ShowRightWay).Draw(Work, Self.GetRightWay(), Work.visibleType);
-            Way(Option.ShowNextBorder).Draw(Work, Self.GetNextBorder(), Work.visibleType);
-            Way(Option.ShowPrevBorder).Draw(Work, Self.GetPrevBorder(), Work.visibleType);
-            Way(Option.ShowCenterWay).Draw(Work, Self.GetCenterWay(), Work.visibleType);
+        virtual bool DrawImpl(RnModelDrawWork& Work, URnLane& Self) override {
+            WayDrawer(Option.ShowLeftWay).Draw(Work, Self.GetLeftWay(), Work.visibleType);
+            WayDrawer(Option.ShowRightWay).Draw(Work, Self.GetRightWay(), Work.visibleType);
+            WayDrawer(Option.ShowNextBorder).Draw(Work, Self.GetNextBorder(), Work.visibleType);
+            WayDrawer(Option.ShowPrevBorder).Draw(Work, Self.GetPrevBorder(), Work.visibleType);
+            WayDrawer(Option.ShowCenterWay).Draw(Work, Self.GetCenterWay(), Work.visibleType);
             auto Center = Self.GetCentralVertex();
-            auto DrawNeighborConnection = [&](bool Enable, TRnRef_T<URnWay> Border, FColor Color)
-            {
-                    if (!Enable || !Border)
-                        return;
+            auto DrawNeighborConnection = [&](bool Enable, TRnRef_T<URnWay> Border, FColor Color) {
+                if (!Enable || !Border)
+                    return;
                 Work.DrawArrow(Center, Border->GetLerpPoint(0.5f), 50, FVector::UpVector, Color);
-            };
+                };
 
             if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::Lane) != 0)
                 FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Center);
@@ -331,19 +329,15 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
         }
     };
 
-    struct Road : public FRnModelRoadDrawer<FRnModelDrawRoadOption>
-    {
-        struct MergeDrawer : public FRnModelRoadDrawer<FRnModelDrawRoadMergeOption>
-        {
-            MergeDrawer(Road& InParent, const FRnModelDrawRoadMergeOption& InOption)
-            : FRnModelRoadDrawer(InOption)
-            , Parent(InParent)
-            {
-                
+    struct RoadDrawer : public FRnModelRoadDrawer<FRnModelDrawRoadOption> {
+        struct MergeDrawer : public FRnModelRoadDrawer<FRnModelDrawRoadMergeOption> {
+            MergeDrawer(RoadDrawer& InParent, const FRnModelDrawRoadMergeOption& InOption)
+                : FRnModelRoadDrawer(InOption)
+                , Parent(InParent) {
+
             }
-            virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override
-            {
-                Lane L(Work.Self->LaneOption);
+            virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override {
+                LaneDrawer L(Work.Self->LaneOption);
 
                 TOptional<EPLATEAURnDir> Dir;
                 if (Option.bShowMergedBorderNoDir == false) {
@@ -351,35 +345,33 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
                 }
                 auto PrevBorder = Self.GetMergedBorder(EPLATEAURnLaneBorderType::Prev, Dir);
                 auto NextBorder = Self.GetMergedBorder(EPLATEAURnLaneBorderType::Next, Dir);
-                Way(L.Option.ShowPrevBorder).Draw(Work, PrevBorder, Work.visibleType);
-                Way(L.Option.ShowNextBorder).Draw(Work, NextBorder, Work.visibleType);
+                WayDrawer(L.Option.ShowPrevBorder).Draw(Work, PrevBorder, Work.visibleType);
+                WayDrawer(L.Option.ShowNextBorder).Draw(Work, NextBorder, Work.visibleType);
 
-                auto Draw = [&](TRnRef_T<URnWay> Border, Way Drawer)
-                {
+                auto Draw = [&](TRnRef_T<URnWay> Border, WayDrawer Drawer) {
                     if (Border) {
                         auto Splits = Border->Split(Option.SplitBorderNum, false);
                         for (auto&& Split : Splits) {
                             Drawer.Draw(Work, Split, Work.visibleType);
                         }
                     }
-                };
-                Draw(PrevBorder, Way( L.Option.ShowPrevBorder));
-                Draw(NextBorder, Way(L.Option.ShowNextBorder));
+                    };
+                Draw(PrevBorder, WayDrawer(L.Option.ShowPrevBorder));
+                Draw(NextBorder, WayDrawer(L.Option.ShowNextBorder));
                 return true;
             }
-            Road& Parent;
+            RoadDrawer& Parent;
         };
 
         struct NormalDrawer : public FRnModelRoadDrawer<FRnModelDrawRoadNormalOption> {
-            NormalDrawer(Road& InParent, const FRnModelDrawRoadNormalOption& InOption)
+            NormalDrawer(RoadDrawer& InParent, const FRnModelDrawRoadNormalOption& InOption)
                 : FRnModelRoadDrawer(InOption)
                 , Parent(InParent) {
 
             }
-            virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override
-            {
-                Lane L(Work.Self->LaneOption);
-                Lane Median(Work.Self->MedianLaneOption);
+            virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override {
+                LaneDrawer L(Work.Self->LaneOption);
+                LaneDrawer Median(Work.Self->MedianLaneOption);
                 for (auto i = 0; i < Self.MainLanes.Num(); ++i) {
                     if (Option.ShowLaneIndex >= 0 && Option.ShowLaneIndex != i)
                         continue;
@@ -389,22 +381,20 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
                 if (Self.MedianLane)
                     Median.Draw(Work, Self.MedianLane, Work.visibleType);
 
-                
+
 
                 return true;
             }
-            Road& Parent;
+            RoadDrawer& Parent;
         };
 
-        struct GroupDrawer : public FRnModelRoadDrawer< FRnModelDrawRoadGroupOption>
-        {
-            GroupDrawer(Road& InParent, const FRnModelDrawRoadGroupOption& InOption)
+        struct GroupDrawer : public FRnModelRoadDrawer< FRnModelDrawRoadGroupOption> {
+            GroupDrawer(RoadDrawer& InParent, const FRnModelDrawRoadGroupOption& InOption)
                 : FRnModelRoadDrawer(InOption)
                 , Parent(InParent) {
 
             }
-            virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override
-            {
+            virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override {
                 auto RoadGroup = URnRoadGroup::CreateRoadGroupOrDefault(&Self);
                 // 2重実行しないように入れておく
                 for (auto R : RoadGroup->Roads)
@@ -413,151 +403,65 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
 
                 auto IsAligned = RoadGroup->IsAligned();
                 auto Color = IsAligned ? FColor::White : FColor::Red;
-                for(auto i = 0; i < RoadGroup->Roads.Num(); ++i)
-                {
+                for (auto i = 0; i < RoadGroup->Roads.Num(); ++i) {
                     auto R = RoadGroup->Roads[i];
-                    auto V= R->GetCentralVertex();
+                    auto V = R->GetCentralVertex();
                     auto GroupName = RoadGroup->Roads[0]->GetName();
-                    FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s[%d]_%s"), *GroupName, i, *R->GetName()),  V, Color);
+                    FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s[%d]_%s"), *GroupName, i, *R->GetName()), V, Color);
 
                     drawer.DrawImpl(Work, *R);
 
-                    
+
                 }
 
                 return true;
             }
-            Road& Parent;
+            RoadDrawer& Parent;
         };
 
-        Road(const FRnModelDrawRoadOption& InOption)
+        RoadDrawer(const FRnModelDrawRoadOption& InOption)
             : FRnModelRoadDrawer(InOption)
             , Merge(*this, InOption.MergeDrawer)
             , Normal(*this, InOption.NormalDrawer)
-        , Group(*this, InOption.GroupDrawer)
-        {
+            , Group(*this, InOption.GroupDrawer) {
 
         }
         MergeDrawer Merge;
         NormalDrawer Normal;
         GroupDrawer Group;
     private:
-        virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override
-        {
-            if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::Road) != 0)
-                FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Self.GetCentralVertex());
+        virtual bool DrawImpl(RnModelDrawWork& Work, URnRoad& Self) override;
 
-            if (Option.bCheckSliceHorizontal) {
-                FLineSegment3D Segment;
-                if (Self.TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType::Next, 200.f, Segment)) {
-
-                    FPLATEAURnDebugEx::DrawLine(Segment.GetStart(), Segment.GetEnd(), FLinearColor::Red);
-                    FPLATEAURnEx::FLineCrossPointResult Res;
-                    URnModel::CanSliceRoadHorizontal(&Self, Segment, Res);
-                    for (auto& Line : Res.TargetLines) {
-                        for (auto& I : Line.Intersections) {
-                            FPLATEAURnDebugEx::DrawSphere(I.Value, 100.f);
-                            auto V = Line.LineString->GetVertexByFloatIndex(I.Key);
-                            FPLATEAURnDebugEx::DrawSphere(V + FVector::UpVector * 30, 100.f, FLinearColor::Blue);
-                            
-                        }
-                    }
-
-                }
-            }
-
-            if(Option.bSliceHorizontal)
-            {
-                Work.DelayExecs.Add([Road = &Self, Model=Work.Model]() 
-                    {
-                        FRnModelCalibrateIntersectionBorderOption Op;
-                        URnRoad* A;
-                        URnRoad* B;
-                        URnRoad* C;
-                        Model->TrySliceRoadHorizontalNearByBorder(Road, Op, A, B, C);
-                    });
-                
-            }
-
-            for (auto BorderType : { EPLATEAURnLaneBorderType::Prev , EPLATEAURnLaneBorderType::Next }) 
-            {
-                if(FRnRoadEx::IsValidBorderAdjacentNeighbor(RnFrom(&Self), BorderType, true) == false)
-                {
-                    FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("Invalid %s"), *Self.GetName()), Self.GetCentralVertex());
-                }
-            }
-            return true;
-        }
         virtual TArray<FRnModelDrawerOf<URnRoad>*> GetChildDrawers() override {
             return TArray<FRnModelDrawerOf<URnRoad>*>
             {
                 &Group,
-                &Merge,
-                &Normal
+                    & Merge,
+                    & Normal
             };
         }
     };
 
-    struct Intersection : public FRnModelIntersectionDrawer<FRnModelDrawIntersectionOption>
-    {
-        Intersection(const FRnModelDrawIntersectionOption& InOption)
+    struct IntersectionDrawer : public FRnModelIntersectionDrawer<FRnModelDrawIntersectionOption> {
+        IntersectionDrawer(const FRnModelDrawIntersectionOption& InOption)
             :FRnModelIntersectionDrawer(InOption) {
 
         }
     private:
-        virtual bool DrawImpl(RnModelDrawWork& Work, URnIntersection& Self) override
-        {
-            Way Border(Option.ShowBorderEdge);
-            Way NonBorder(Option.ShowNonBorderEdge);
-
-            for (auto&& Edge : Self.GetEdges()) 
-            {
-                if(Edge->IsBorder())
-                {
-                    Border.Draw(Work, Edge->GetBorder(), Work.visibleType);
-                }
-                else
-                {
-                    NonBorder.Draw(Work, Edge->GetBorder(), Work.visibleType);
-                }
-
-                if(Option.bShowEdgeNormal)
-                {
-                    auto Center = Edge->GetCenterPoint();
-                    auto Normal = FRnIntersectionEx::GetEdgeNormal(Edge);
-                    FPLATEAURnDebugEx::DrawArrow(Center, Center + Normal * 100, FColor::White);
-                }
-            }
-
-            if (Option.bShowTrack)
-            {
-                for(auto Track : Self.GetTracks())
-                {
-                    if (Option.showTrackColor.Contains(Track->TurnType) == false)
-                        continue;
-                    auto V = Option.showTrackColor[Track->TurnType];
-                    FPLATEAURnDebugEx::DrawArrow(Track->FromBorder->GetLerpPoint(0.5f), Track->ToBorder->GetLerpPoint(0.5f), V);
-                }
-            }
-
-            if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::Intersection) != 0)
-                FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Self.GetCentralVertex());
-            return true;
-        }
+        virtual bool DrawImpl(RnModelDrawWork& Work, URnIntersection& Self) override;
     };
 
-    struct SideWalk : public FRnModelSideWalkDrawer<FRnModelDrawSideWalkOption> {
-        SideWalk(const FRnModelDrawSideWalkOption& InOption)
+    struct SideWalkDrawer : public FRnModelSideWalkDrawer<FRnModelDrawSideWalkOption> {
+        SideWalkDrawer(const FRnModelDrawSideWalkOption& InOption)
             :FRnModelSideWalkDrawer(InOption) {
 
         }
     private:
-        virtual bool DrawImpl(RnModelDrawWork& Work, URnSideWalk& Self) override
-        {
-            Way(Option.ShowInsideWay).Draw(Work,Self.GetInsideWay(), Work.visibleType);
-            Way(Option.ShowOutsideWay).Draw(Work, Self.GetOutsideWay(), Work.visibleType);
-            Way(Option.ShowStartEdgeWay).Draw(Work, Self.GetStartEdgeWay(), Work.visibleType);
-            Way(Option.ShowEndEdgeWay).Draw(Work, Self.GetEndEdgeWay(), Work.visibleType);
+        virtual bool DrawImpl(RnModelDrawWork& Work, URnSideWalk& Self) override {
+            WayDrawer(Option.ShowInsideWay).Draw(Work, Self.GetInsideWay(), Work.visibleType);
+            WayDrawer(Option.ShowOutsideWay).Draw(Work, Self.GetOutsideWay(), Work.visibleType);
+            WayDrawer(Option.ShowStartEdgeWay).Draw(Work, Self.GetStartEdgeWay(), Work.visibleType);
+            WayDrawer(Option.ShowEndEdgeWay).Draw(Work, Self.GetEndEdgeWay(), Work.visibleType);
 
             if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::SideWalk) != 0)
                 FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Self.GetCentralVertex());
@@ -565,9 +469,119 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
         }
     };
 
-    Road RoadDrawer(RoadOption);
-    Intersection IntersectionDrawer(IntersectionOption);
-    SideWalk SideWalkDrawer(SideWalkOption);
+    bool RoadDrawer::DrawImpl(RnModelDrawWork& Work, URnRoad& Self) {
+        if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::Road) != 0)
+            FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Self.GetCentralVertex());
+
+        if (Option.bCheckSliceHorizontal) {
+            FLineSegment3D Segment;
+            if (Self.TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType::Next, 200.f, Segment)) {
+
+                FPLATEAURnDebugEx::DrawLine(Segment.GetStart(), Segment.GetEnd(), FLinearColor::Red);
+                FPLATEAURnEx::FLineCrossPointResult Res;
+                URnModel::CanSliceRoadHorizontal(&Self, Segment, Res);
+                for (auto& Line : Res.TargetLines) {
+                    for (auto& I : Line.Intersections) {
+                        FPLATEAURnDebugEx::DrawSphere(I.Value, 100.f);
+                        auto V = Line.LineString->GetVertexByFloatIndex(I.Key);
+                        FPLATEAURnDebugEx::DrawSphere(V + FVector::UpVector * 30, 100.f, FLinearColor::Blue);
+
+                    }
+                }
+
+            }
+        }
+
+        if (Option.bSliceHorizontal) {
+            Work.DelayExecs.Add([Road = &Self, Model = Work.Model]() {
+                FRnModelCalibrateIntersectionBorderOption Op;
+                URnRoad* A;
+                URnRoad* B;
+                URnRoad* C;
+                Model->TrySliceRoadHorizontalNearByBorder(Road, Op, A, B, C);
+                });
+
+        }
+
+        if(Option.bMerge2Intersection)
+        {
+            Work.DelayExecs.Add([Road = &Self, Model = Work.Model]() {
+                
+                if(Road->TryMerge2NeighborIntersection(EPLATEAURnLaneBorderType::Next))
+                {
+                    
+                }
+                else
+                {
+                    Road->TryMerge2NeighborIntersection(EPLATEAURnLaneBorderType::Prev);                    
+                }
+                });
+        }
+
+        for (auto BorderType : { EPLATEAURnLaneBorderType::Prev , EPLATEAURnLaneBorderType::Next }) {
+            if (FRnRoadEx::IsValidBorderAdjacentNeighbor(RnFrom(&Self), BorderType, true) == false) {
+                FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("Invalid %s"), *Self.GetName()), Self.GetCentralVertex());
+            }
+        }
+        SideWalkDrawer SideWalkDrawer(Work.Self->SideWalkOption);
+        for (auto Sw : Self.GetSideWalks())
+            SideWalkDrawer.Draw(Work, Sw, ERnModelDrawerVisibleType::SceneSelected);
+        return true;
+    }
+
+    bool IntersectionDrawer::DrawImpl(RnModelDrawWork& Work, URnIntersection& Self)
+    {
+        WayDrawer Border(Option.ShowBorderEdge);
+        WayDrawer NonBorder(Option.ShowNonBorderEdge);
+
+        for (auto&& Edge : Self.GetEdges()) {
+            if (Edge->IsBorder()) {
+                Border.Draw(Work, Edge->GetBorder(), Work.visibleType);
+            }
+            else {
+                NonBorder.Draw(Work, Edge->GetBorder(), Work.visibleType);
+            }
+
+            if (Option.bShowEdgeNormal) {
+                auto Center = Edge->GetCenterPoint();
+                auto Normal = FRnIntersectionEx::GetEdgeNormal(Edge);
+                FPLATEAURnDebugEx::DrawArrow(Center, Center + Normal * 100, FColor::White);
+            }
+        }
+
+        if (Option.bShowTrack) {
+            for (auto Track : Self.GetTracks()) {
+                if (Option.showTrackColor.Contains(Track->TurnType) == false)
+                    continue;
+                auto V = Option.showTrackColor[Track->TurnType];
+                FPLATEAURnDebugEx::DrawArrow(Track->FromBorder->GetLerpPoint(0.5f), Track->ToBorder->GetLerpPoint(0.5f), V);
+            }
+        }
+
+        if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::Intersection) != 0)
+            FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Self.GetCentralVertex());
+
+        
+        SideWalkDrawer SideWalkDrawer(Work.Self->SideWalkOption);
+        for (auto Sw : Self.GetSideWalks())
+            SideWalkDrawer.Draw(Work, Sw, ERnModelDrawerVisibleType::SceneSelected);
+        return true;
+    }
+}
+
+void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
+{
+    if (bVisible == false)
+        return;
+
+    if (!Model)
+        return;
+
+  
+
+    ::RoadDrawer RoadDrawer(RoadOption);
+    ::IntersectionDrawer IntersectionDrawer(IntersectionOption);
+    ::SideWalkDrawer SideWalkDrawer(SideWalkOption);
 
     RnModelDrawWork Work(this, Model);
 
@@ -580,6 +594,7 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
     }
     // 実行ボタン代わりなので毎フレームリセット
     RoadOption.bSliceHorizontal = false;
+    RoadOption.bMerge2Intersection = false;
 
     for (auto intersection : Model->GetIntersections()) {
         if (bShowOnlyTargets && ShowTargetNames.Contains(intersection->GetName()) == false)
@@ -588,6 +603,8 @@ void FPLATEAURnModelDrawerDebug::Draw(URnModel* Model)
     }
 
     for (auto sideWalk : Model->GetSideWalks()) {
+        if (bShowOnlyTargets && ShowTargetNames.Contains(sideWalk->GetName()) == false)
+            continue;
         SideWalkDrawer.Draw(Work, sideWalk, ERnModelDrawerVisibleType::NonSelected);
     }
 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.cpp
@@ -381,8 +381,16 @@ namespace
                 if (Self.MedianLane)
                     Median.Draw(Work, Self.MedianLane, Work.visibleType);
 
-
-
+                if(Self.GetNext() != nullptr &&  Option.bShowNextConnection)
+                {
+                    auto V = Self.GetNext()->GetCentralVertex();
+                    Work.DrawArrow(Self.GetCentralVertex(), V, 0.5f, FVector::UpVector, FLinearColor::Red);
+                }
+                if(Self.GetPrev() != nullptr && Option.bShowPrevConnection)
+                {
+                    auto V = Self.GetPrev()->GetCentralVertex();
+                    Work.DrawArrow(Self.GetCentralVertex(), V, 0.5f, FVector::UpVector, FLinearColor::Red);
+                }
                 return true;
             }
             RoadDrawer& Parent;
@@ -465,6 +473,10 @@ namespace
 
             if ((Work.Self->ShowPartsType & (int32)ERnPartsTypeMask::SideWalk) != 0)
                 FPLATEAURnDebugEx::DrawString(FString::Printf(TEXT("%s"), *Self.GetName()), Self.GetCentralVertex());
+            if(Option.bCheck)
+            {
+                auto CheckRes = Self.Check();
+            }
             return true;
         }
     };
@@ -475,7 +487,7 @@ namespace
 
         if (Option.bCheckSliceHorizontal) {
             FLineSegment3D Segment;
-            if (Self.TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType::Next, 200.f, Segment)) {
+            if (Self.TryGetVerticalSliceSegment(Option.CheckSliceHorizontalDir, Option.CheckSliceHorizontalOffset, Segment)) {
 
                 FPLATEAURnDebugEx::DrawLine(Segment.GetStart(), Segment.GetEnd(), FLinearColor::Red);
                 FPLATEAURnEx::FLineCrossPointResult Res;
@@ -485,10 +497,8 @@ namespace
                         FPLATEAURnDebugEx::DrawSphere(I.Value, 100.f);
                         auto V = Line.LineString->GetVertexByFloatIndex(I.Key);
                         FPLATEAURnDebugEx::DrawSphere(V + FVector::UpVector * 30, 100.f, FLinearColor::Blue);
-
                     }
                 }
-
             }
         }
 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnIntersection.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnIntersection.cpp
@@ -253,16 +253,39 @@ void URnIntersection::RemoveEdges(const TRnRef_T<URnRoadBase>& Road) {
     RemoveEdges([&](const TRnRef_T<URnIntersectionEdge>& Edge) { return Edge->GetRoad() == Road; });
 }
 
-void URnIntersection::RemoveEdges(const TFunction<bool(const TRnRef_T<URnIntersectionEdge>&)>& Predicate) {
-    for (int32 i = Edges.Num() - 1; i >= 0; --i) {
-        if (Predicate((Edges)[i])) {
-            Edges.RemoveAt(i);
-        }
+int32 URnIntersection::RemoveEdges(const TFunction<bool(const TRnRef_T<URnIntersectionEdge>&)>& Predicate)
+{
+    auto Targets = Edges.FilterByPredicate(Predicate);
+    for (auto& Target : Targets) {
+        RemoveEdge(Target);
     }
+    return Targets.Num();
 }
 
-void URnIntersection::ReplaceEdges(const TRnRef_T<URnRoadBase>& Road, const TArray<TRnRef_T<URnWay>>& NewBorders) {
-    RemoveEdges(Road);
+int32 URnIntersection::RemoveEdges(const TRnRef_T<URnWay>& Way)
+{
+    return RemoveEdges([&](const TRnRef_T<URnIntersectionEdge>& Edge) {
+        return Edge->GetBorder()->IsSameLineReference(Way);
+    });
+}
+
+void URnIntersection::ReplaceEdges(const TRnRef_T<URnRoad>& Road, EPLATEAURnLaneBorderType BorderType, const TArray<TRnRef_T<URnWay>>& NewBorders)
+{
+    if (!Road)
+        return;
+
+    auto BorderWays = Road->GetBorderWays(BorderType);
+    for(auto Way : BorderWays)
+    {
+        auto RemoveCount = RemoveEdges(Way);
+        if(RemoveCount != 1)
+        {
+            UE_LOG(LogTemp, Warning
+                , TEXT("URnIntersection::ReplaceEdges:削除しようとしたエッジが交差点に存在しませんでした. Road: %s, BorderType: %d, RemoveCount: %d")
+                , *Road->GetName(), BorderType, RemoveCount);
+        }
+    }
+
     for (const auto& Border : NewBorders) {
         AddEdge(Road, Border);
     }
@@ -280,9 +303,13 @@ int32 URnIntersection::ReplaceEdgeLink(TRnRef_T<URnWay> Border, TRnRef_T<URnRoad
     return Count;
 }
 
-void URnIntersection::AddEdge(const TRnRef_T<URnRoadBase>& Road, const TRnRef_T<URnWay>& Border) {
+bool URnIntersection::AddEdge(const TRnRef_T<URnRoadBase>& Road, const TRnRef_T<URnWay>& Border) {
+    if (!Border)
+        return false;
+        
     auto NewEdge = RnNew<URnIntersectionEdge>(Road, Border);
     Edges.Add(NewEdge);
+    return true;
 }
 
 bool URnIntersection::HasEdge(const TRnRef_T<URnRoadBase>& Road) const {
@@ -291,6 +318,26 @@ bool URnIntersection::HasEdge(const TRnRef_T<URnRoadBase>& Road) const {
 
 bool URnIntersection::HasEdge(const TRnRef_T<URnRoadBase>& Road, const TRnRef_T<URnWay>& Border) const {
     return GetEdgeBy(Road, Border) != nullptr;
+}
+
+bool URnIntersection::IsAligned() const {
+    const int32 EdgeCount = Edges.Num();
+    if (EdgeCount == 0) {
+        return true;
+    }
+
+    for (int32 i = 0; i < EdgeCount; ++i) {
+        const URnIntersectionEdge* E0 = Edges[i];
+        const URnIntersectionEdge* E1 = Edges[(i + 1) % EdgeCount];
+
+        // e0 の境界線の最後のポイントと、e1 の境界線の先頭のポイントを比較する
+        const auto LastPoint = E0->GetBorder()->GetPoint(-1);
+        const auto FirstPoint = E1->GetBorder()->GetPoint(0);
+        if (FirstPoint != LastPoint) {
+            return false;
+        }
+    }
+    return true;
 }
 
 void URnIntersection::Align()
@@ -445,6 +492,19 @@ void URnIntersection::AlignEdgeNormal(TRnRef_T<URnIntersectionEdge> edge)
         edge->GetBorder()->IsReverseNormal = false;
 }
 
+bool URnIntersection::RemoveEdge(URnIntersectionEdge* Edge)
+{
+    auto RemoveCount = Edges.Remove(Edge);
+    if (RemoveCount == 0)
+        return false;
+
+    Tracks.RemoveAll([&](const URnTrack* Track) {
+        return Track->ContainsBorder(Edge->GetBorder());
+        });
+
+    return true;
+}
+
 bool FRnIntersectionEx::FEdgeGroup::IsValid() const
 {
     if (Edges.IsEmpty())
@@ -589,7 +649,78 @@ void URnIntersection::SeparateContinuousBorder() {
 
 void URnIntersection::BuildTracks()
 {
+    BuildTracks(FBuildTrackOption::Default());
+}
+
+void URnIntersection::BuildTracks(const FBuildTrackOption& Option) {
     Align();
     FRnTracksBuilder builder;
-    builder.BuildTracks(this, FBuildTrackOption::Default());
+    builder.BuildTracks(this, Option);
+}
+bool URnIntersection::Check()
+{
+    Align();
+    if(IsAligned() == false)
+    {
+        UE_LOG(LogTemp, Error, TEXT("ループしていない輪郭の交差点%s"), *GetTargetTransName());
+    }
+    return true;
+}
+// MergeContinuousNonBorderEdge
+// 境界線以外のエッジが連続している場合、一つのエッジにまとめます。
+void URnIntersection::MergeContinuousNonBorderEdge() {
+    // エッジの整列処理。各エッジが連結し、時計回りになるように並んでいる前提です。
+    Align();
+
+    for (int32 i = 0; i < Edges.Num(); ++i) {
+        auto Edge = Edges[i];
+
+        // 境界線であればスキップ
+        if (Edge->IsBorder()) {
+            continue;
+        }
+
+        // 連続する非境界エッジがある間、マージを繰り返す
+        while (Edges.Num() > 1 && !Edges[(i + 1) % Edges.Num()]->IsBorder()) 
+        {
+            auto NextEdge = Edges[(i + 1) % Edges.Num()];
+
+            // 現在のエッジの Border と次のエッジの Border をクローンしてマージ
+            URnWay* ClonedWay1 = Edge->GetBorder()->Clone(false);
+            URnWay* ClonedWay2 = NextEdge->GetBorder()->Clone(false);
+            URnWay* MergedWay = URnWay::CreateMergedWay(ClonedWay1, ClonedWay2, false);
+
+            // マージ結果を現在のエッジにセット
+            Edge->SetBorder(MergedWay);
+
+            // 次のエッジをリストから削除
+            Edges.RemoveAt((i + 1) % Edges.Num());
+            UE_LOG(LogTemp, Log, TEXT("Merge NonBorder Edge %s"), *GetTargetTransName());
+
+            // i が末尾で削除された場合に備え、i を調整
+            i = FMath::Min(i, Edges.Num() - 1);
+        }
+    }
+}
+
+void URnIntersection::ReplaceNeighbor(URnWay* BorderWay, URnRoadBase* To)
+{
+    if (BorderWay == nullptr) {
+        return;
+    }
+
+    bool bFound = false;
+    for (URnIntersectionEdge* Edge : Edges) {
+        // Border が存在し、IsSameLineReference で同一か判定
+        if (Edge->IsValid() && Edge->GetBorder()->IsSameLineReference(BorderWay)) {
+            Edge->SetRoad(To);
+            bFound = true;
+        }
+    }
+
+    // 該当する境界線が見つからなかった場合はエラーログを出力
+    if (!bFound) {
+        UE_LOG(LogTemp, Error, TEXT("境界線 %s が %s に存在しませんでした"),
+               *BorderWay->GetName(), *GetName());
+    }
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLane.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLane.cpp
@@ -300,6 +300,37 @@ TRnRef_T<URnRoadBase> URnLane::GetPrevRoad()
     return Ret[0];
 }
 
+bool URnLane::Check()
+{
+    // LeftWay, RightWay, PrevBorder, NextBorder が全て有効な場合のみチェック
+    if (LeftWay && RightWay && PrevBorder && NextBorder) {
+        // 左側 Way の先頭の点が PrevBorder に含まれているかチェック
+        if (!PrevBorder->GetLineString()->GetPoints().Contains(LeftWay->GetPoint(0))) {
+            UE_LOG(LogTemp, Error, TEXT("PrevBorderにLeftWay[0]が含まれていません. %s"), *Parent->GetTargetTransName());
+            return false;
+        }
+        // 右側 Way の先頭の点が PrevBorder に含まれているかチェック
+        if (!PrevBorder->GetLineString()->GetPoints().Contains(RightWay->GetPoint(0))) {
+            UE_LOG(LogTemp, Error, TEXT("PrevBorderにRightWay[0]が含まれていません. %s"), *Parent->GetTargetTransName());
+            return false;
+        }
+
+        // NextBorder には各 Way の末尾の点が含まれているはずです。
+        const int32 LeftLastIndex = LeftWay->Count() - 1;
+        const int32 RightLastIndex = RightWay->Count() - 1;
+        if (!NextBorder->GetLineString()->GetPoints().Contains(LeftWay->GetPoint(LeftLastIndex))) {
+            UE_LOG(LogTemp, Error, TEXT("NextBorderにLeftWay[最後]が含まれていません. %s"), *Parent->GetTargetTransName());
+            return false;
+        }
+        if (!NextBorder->GetLineString()->GetPoints().Contains(RightWay->GetPoint(RightLastIndex))) {
+            UE_LOG(LogTemp, Error, TEXT("NextBorderにRightWay[最後]が含まれていません. %s"), *Parent->GetTargetTransName());
+            return false;
+        }
+    }
+
+    return true;
+}
+
 TRnRef_T<URnLane> URnLane::CreateOneWayLane(TRnRef_T<URnWay> way)
 {
     return RnNew<URnLane>(way, nullptr, nullptr, nullptr);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLane.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLane.cpp
@@ -5,12 +5,12 @@
 #include "RoadNetwork/Util/PLATEAUVectorEx.h"
 
 URnLane::URnLane()
-    : bIsReverse(false) {
+    : bIsReversed(false) {
 }
 
 URnLane::URnLane(const TRnRef_T<URnWay>& InLeftWay, const TRnRef_T<URnWay>& InRightWay,
     const TRnRef_T<URnWay>& InPrevBorder, const TRnRef_T<URnWay>& InNextBorder)
-    : bIsReverse(false) {
+    : bIsReversed(false) {
     Init(InLeftWay, InRightWay, InPrevBorder, InNextBorder);
 
 }
@@ -186,7 +186,7 @@ float URnLane::CalcMinWidth() const
 }
 
 void URnLane::Reverse() {
-    bIsReverse = !bIsReverse;
+    bIsReversed = !bIsReversed;
     Swap(PrevBorder, NextBorder);
     Swap(LeftWay, RightWay);
     for (auto Way : GetAllWays())
@@ -279,7 +279,7 @@ TRnRef_T<URnLane> URnLane::Clone() const {
     NewLane->RightWay = RightWay ? RightWay->Clone(true) : nullptr;
     NewLane->PrevBorder = PrevBorder ? PrevBorder->Clone(true) : nullptr;
     NewLane->NextBorder = NextBorder ? NextBorder->Clone(true) : nullptr;
-    NewLane->bIsReverse = bIsReverse;
+    NewLane->bIsReversed = bIsReversed;
     if (CenterWay) NewLane->CenterWay = CenterWay->Clone(true);
     return NewLane;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLineString.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnLineString.cpp
@@ -318,11 +318,18 @@ void URnLineString::GetNearestPoint(const FVector& Pos, FVector& OutNearest, flo
         const FVector End = GetVertex(i+1);
         const FVector ProjectedPoint = FMath::ClosestPointOnSegment(Pos, Start, End);
 
+
+        auto Diff = (End - Start).Size();
+        if (Diff < 1e-8f)
+            continue;
+
         const float Distance = (Pos - ProjectedPoint).Size();
         if (Distance < OutDistance) {
+
             OutDistance = Distance;
             OutNearest = ProjectedPoint;
-            OutPointIndex = i + (ProjectedPoint - Start).Size() / (End - Start).Size();
+            auto Offset = (ProjectedPoint - Start);
+            OutPointIndex = i + Offset.Size() / Diff;
         }
     }
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -517,24 +517,6 @@ namespace
             else if (IsPointShared(StartEdgeWay, { NextInsideWay, NextOutsideWay })) {
                 Swap(StartEdgeWay, EndEdgeWay);
             }
-           /* else 
-            {
-                if (StartEdgeWay) {
-                    const float PrevSign = LineSegment2D.Sign(GetMid2D(Inside->Prev->GetPoint(0), Inside->Prev->GetPoint(1)));
-                    const float StartSign = LineSegment2D.Sign(As2D(StartEdgeWay->GetPoint(0)));
-                    if (PrevSign != StartSign) {
-                        Swap(StartEdgeWay, EndEdgeWay);
-                    }
-                }
-                if (EndEdgeWay) {
-                    const float PrevSign = LineSegment2D.Sign(GetMid2D(Inside->Next->GetPoint(0), Inside->Next->GetPoint(1)));
-                    const float StartSign = LineSegment2D.Sign(As2D(EndEdgeWay->GetPoint(0)));
-
-                    if (PrevSign != StartSign) {
-                        Swap(StartEdgeWay, EndEdgeWay);
-                    }
-                }
-            }*/
             
             TArray<URnPoint*> points{ Inside->MidPoint, Outside->MidPoint };
             URnWay* MidEdgeWay = URnWay::Create(URnLineString::Create(points));

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -736,7 +736,7 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
         auto prevLeftWay = CopyWay(left.prev, lane->GetLeftWay());
         auto prevRightWay = CopyWay(right.prev, lane->GetRightWay());
 
-        auto isReverseLane = lane->GetIsReverse();
+        auto isReverseLane = lane->GetIsReversed();
 
         // 分割個所の境界線
         auto midBorderWay = RnNew<URnWay>(URnLineString::Create(TArray<URnPoint*> { left.midPoint, right.midPoint }));
@@ -749,7 +749,7 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
         lane->SetBorder(laneMidBorderType, midBorderWay);
 
         auto newLane = RnNew<URnLane>(nextLeftWay, nextRightWay, nullptr, nullptr);
-        newLane->SetIsReverse(isReverseLane);
+        newLane->SetIsReversed(isReverseLane);
         newLane->SetBorder(laneMidBorderType, nextBorder);
         newLane->SetBorder( FPLATEAURnLaneBorderTypeEx::GetOpposite(laneMidBorderType), midBorderWay);
         if (lane->IsMedianLane()) {

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnModel.cpp
@@ -223,21 +223,11 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
         URnIntersection* Intersection;
         EPLATEAURnLaneBorderType BorderType;
     };
-    auto IsNeighbor = [&](URnRoad* r, URnIntersection* neighbor) {
-        return r->Next == neighbor || r->Prev == neighbor;
-        };
+  
     struct SideInfo {
         URnRoad* FarSide = nullptr;
         URnRoad* NearSide = nullptr;
     };
-
-    auto CheckSliceResult = [&](const FSliceRoadHorizontalResult& Res, URnIntersection* Neighbor) {
-        auto nearRoad = Res.NextRoad;
-        auto farRoad = Res.PrevRoad;
-        if (IsNeighbor(Res.PrevRoad, Neighbor))
-            Swap(nearRoad, farRoad);
-        return SideInfo({ farRoad, nearRoad });
-        };
 
     TArray<FNeighborInfo> Neighbors;
     for (EPLATEAURnLaneBorderType BorderType : {EPLATEAURnLaneBorderType::Prev, EPLATEAURnLaneBorderType::Next}) {
@@ -260,10 +250,9 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
         if (Road->TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType::Next, OffsetLength, Segment)) {
             FSliceRoadHorizontalResult Result = SliceRoadHorizontal(Road, Segment);
             if (Result.Result == ERoadCutResult::Success) {
-                auto Check = CheckSliceResult(Result, NextIntersection);
-                OutCenterSideRoad = Check.FarSide;
-                OutNextSideRoad = Check.NearSide;
-                Road = Check.FarSide;
+                OutCenterSideRoad = Result.PrevRoad;
+                OutNextSideRoad = Result.NextRoad;
+                Road = Result.PrevRoad;
             }
             else {
                 Success = false;
@@ -279,9 +268,8 @@ bool URnModel::TrySliceRoadHorizontalNearByBorder(
         if (Road->TryGetVerticalSliceSegment(EPLATEAURnLaneBorderType::Prev, OffsetLength, Segment)) {
             FSliceRoadHorizontalResult Result = SliceRoadHorizontal(Road, Segment);
             if (Result.Result == ERoadCutResult::Success) {
-                auto Check = CheckSliceResult(Result, PrevIntersection);
-                OutCenterSideRoad = Check.FarSide;
-                OutPrevSideRoad = Check.NearSide;
+                OutCenterSideRoad = Result.NextRoad;
+                OutPrevSideRoad = Result.PrevRoad;
             }
             else {
                 Success = false;
@@ -470,11 +458,11 @@ namespace
     }
 
 
-    // key: Original LineString, value: (prev, next, midPoint) after split
+    // key: Original LineString, value: SliceRoadMapValue after split
     struct SliceRoadMapValue {
-        URnLineString* prev;
-        URnLineString* next;
-        URnPoint* midPoint;
+        URnLineString* Prev;
+        URnLineString* Next;
+        URnPoint* MidPoint;
     };
 
     void SliceSideWalks(
@@ -483,7 +471,7 @@ namespace
         const FLineSegment2D& LineSegment2D,
         const TMap<URnLineString*, SliceRoadMapValue>& LineTable,
         URnRoadBase* NewNextRoad,
-        TFunction<bool(URnSideWalk*)> IsPrevSide)
+        const TFunction<bool(URnSideWalk*)>& IsPrevSide)
     {
         auto CopySideWalks = SrcSideWalks;
         for (URnSideWalk* SideWalk : CopySideWalks) {
@@ -499,43 +487,57 @@ namespace
                 continue;
             }
 
-            URnWay* NextInsideWay = CopyWay(Inside ? Inside->next : nullptr, SideWalk->GetInsideWay());
-            URnWay* NextOutsideWay = CopyWay(Outside ? Outside->next : nullptr, SideWalk->GetOutsideWay());
+            URnWay* NextInsideWay = CopyWay(Inside ? Inside->Next : nullptr, SideWalk->GetInsideWay());
+            URnWay* NextOutsideWay = CopyWay(Outside ? Outside->Next : nullptr, SideWalk->GetOutsideWay());
 
-            URnWay* PrevInsideWay = CopyWay(Inside ? Inside->prev : nullptr, SideWalk->GetInsideWay());
-            URnWay* PrevOutsideWay = CopyWay(Outside ? Outside->prev : nullptr, SideWalk->GetOutsideWay());
+            URnWay* PrevInsideWay = CopyWay(Inside ? Inside->Prev : nullptr, SideWalk->GetInsideWay());
+            URnWay* PrevOutsideWay = CopyWay(Outside ? Outside->Prev : nullptr, SideWalk->GetOutsideWay());
+
+            auto IsPointShared = [](const URnWay* Way, std::initializer_list<const URnWay*> TargetWays)-> bool {
+                if (!Way)
+                    return false;
+                for (auto W : TargetWays) {
+                    if (FRnLineStringEx::IsPointShared(Way->LineString, W->LineString))
+                        return true;
+                }
+                return false;
+            };
+
+            // 元のSideWay -> Prev側
+            // 新しいSideWay -> Next側
+            // となるようにする
 
             auto StartEdgeWay = SideWalk->GetStartEdgeWay();
             auto EndEdgeWay = SideWalk->GetEndEdgeWay();
-            constexpr auto Plane = FPLATEAURnDef::Plane;
-            if (StartEdgeWay) {
-                const float PrevSign = LineSegment2D.Sign(FAxisPlaneEx::ToVector2D(
-                    FMath::Lerp(Inside->prev->GetPoint(0)->Vertex,
-                        Inside->prev->GetPoint(1)->GetVertex(), 0.5f),
-                    Plane));
-
-                const float StartSign = LineSegment2D.Sign(FAxisPlaneEx::ToVector2D(
-                    StartEdgeWay->GetPoint(0)->GetVertex(), Plane));
-
-                if (PrevSign != StartSign) {
-                    Swap(StartEdgeWay, EndEdgeWay);
-                }
+            // EndEdgeWayがPrev側のSideWayとポイント共有していたら逆
+            if (IsPointShared(EndEdgeWay, { PrevInsideWay, PrevOutsideWay })) {
+                Swap(StartEdgeWay, EndEdgeWay);
             }
-            else if (EndEdgeWay) {
-                const float PrevSign = LineSegment2D.Sign(FAxisPlaneEx::ToVector2D(
-                    FMath::Lerp(Inside->next->GetPoint(0)->GetVertex(),
-                        Inside->next->GetPoint(1)->GetVertex(), 0.5f),
-                    Plane));
-
-                const float StartSign = LineSegment2D.Sign(FAxisPlaneEx::ToVector2D(
-                    EndEdgeWay->GetPoint(0)->GetVertex(), Plane));
-
-                if (PrevSign != StartSign) {
-                    Swap(StartEdgeWay, EndEdgeWay);
-                }
+            // StartEdgeWayがNext側のSideWayとポイント共有していたら逆
+            else if (IsPointShared(StartEdgeWay, { NextInsideWay, NextOutsideWay })) {
+                Swap(StartEdgeWay, EndEdgeWay);
             }
-            TArray<URnPoint*> points{ Inside->midPoint, Outside->midPoint };
-            URnWay* MidEdgeWay = RnNew<URnWay>(URnLineString::Create(points));
+           /* else 
+            {
+                if (StartEdgeWay) {
+                    const float PrevSign = LineSegment2D.Sign(GetMid2D(Inside->Prev->GetPoint(0), Inside->Prev->GetPoint(1)));
+                    const float StartSign = LineSegment2D.Sign(As2D(StartEdgeWay->GetPoint(0)));
+                    if (PrevSign != StartSign) {
+                        Swap(StartEdgeWay, EndEdgeWay);
+                    }
+                }
+                if (EndEdgeWay) {
+                    const float PrevSign = LineSegment2D.Sign(GetMid2D(Inside->Next->GetPoint(0), Inside->Next->GetPoint(1)));
+                    const float StartSign = LineSegment2D.Sign(As2D(EndEdgeWay->GetPoint(0)));
+
+                    if (PrevSign != StartSign) {
+                        Swap(StartEdgeWay, EndEdgeWay);
+                    }
+                }
+            }*/
+            
+            TArray<URnPoint*> points{ Inside->MidPoint, Outside->MidPoint };
+            URnWay* MidEdgeWay = URnWay::Create(URnLineString::Create(points));
 
             URnSideWalk* NewSideWalk = URnSideWalk::Create(
                 NewNextRoad, NextOutsideWay, NextInsideWay, MidEdgeWay, EndEdgeWay, SideWalk->GetLaneType());
@@ -621,17 +623,20 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
 
     TMap<URnLineString*, SliceRoadMapValue> LineTable;
 
+    auto OldPrevBorders = Road->GetBorderWays(EPLATEAURnLaneBorderType::Prev);
+    auto OldNextBorders = Road->GetBorderWays(EPLATEAURnLaneBorderType::Next);
+
     // Points for prev/next side determination
     TSet<URnPoint*> PrevBorderPoints;
     TSet<URnPoint*> NextBorderPoints;
 
     // Collect border points
-    for (URnWay* Way : Road->GetBorderWays(EPLATEAURnLaneBorderType::Prev)) {
+    for (URnWay* Way : OldPrevBorders) {
         for (URnPoint* Point : Way->GetPoints()) {
             PrevBorderPoints.Add(Point);
         }
     }
-    for (URnWay* Way : Road->GetBorderWays(EPLATEAURnLaneBorderType::Next)) {
+    for (URnWay* Way : OldNextBorders) {
         for (URnPoint* Point : Way->GetPoints()) {
             NextBorderPoints.Add(Point);
         }
@@ -701,8 +706,8 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
         auto MaxPrevScore = FLT_MAX;
         for(auto& L : LineTable)
         {
-            auto PrevScore = Front->CalcProximityScore(L.Value.prev);
-            auto NextScore = Front->CalcProximityScore(L.Value.next);
+            auto PrevScore = Front->CalcProximityScore(L.Value.Prev);
+            auto NextScore = Front->CalcProximityScore(L.Value.Next);
 
             if (PrevScore.IsSet() && PrevScore.GetValue() < MinPrevScore) {
                 MinPrevScore = PrevScore.GetValue();
@@ -720,7 +725,7 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
         }
     }
 
-    // 新しく生成されるRoad
+    // 新しく生成されるRoad(Next側に挿入される)
     auto newNextRoad = RnNew<URnRoad>(Road->GetTargetTrans());
 
     // roadをprev/next側で分断して, next側をnewRoadにする
@@ -730,27 +735,27 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
         auto left = LineTable[lane->GetLeftWay()->LineString];
         auto right = LineTable[lane->GetRightWay()->LineString];
 
-        auto nextLeftWay = CopyWay(left.next, lane->GetLeftWay());
-        auto nextRightWay = CopyWay(right.next, lane->GetRightWay());
+        auto nextLeftWay = CopyWay(left.Next, lane->GetLeftWay());
+        auto nextRightWay = CopyWay(right.Next, lane->GetRightWay());
 
-        auto prevLeftWay = CopyWay(left.prev, lane->GetLeftWay());
-        auto prevRightWay = CopyWay(right.prev, lane->GetRightWay());
+        auto prevLeftWay = CopyWay(left.Prev, lane->GetLeftWay());
+        auto prevRightWay = CopyWay(right.Prev, lane->GetRightWay());
 
         auto isReverseLane = lane->GetIsReversed();
 
         // 分割個所の境界線
-        auto midBorderWay = RnNew<URnWay>(URnLineString::Create(TArray<URnPoint*> { left.midPoint, right.midPoint }));
+        auto midBorderWay = RnNew<URnWay>(URnLineString::Create(TArray<URnPoint*> { left.MidPoint, right.MidPoint }));
 
         // 順方向ならNext/逆方向ならPrevが中間地点になる
         auto laneMidBorderType = isReverseLane ? EPLATEAURnLaneBorderType::Prev : EPLATEAURnLaneBorderType::Next;
 
         // 以前のボーダーは新しいボーダーに設定する
-        auto nextBorder = lane->GetBorder(laneMidBorderType);
+        auto newLaneBorder = lane->GetBorder(laneMidBorderType);
         lane->SetBorder(laneMidBorderType, midBorderWay);
 
         auto newLane = RnNew<URnLane>(nextLeftWay, nextRightWay, nullptr, nullptr);
         newLane->SetIsReversed(isReverseLane);
-        newLane->SetBorder(laneMidBorderType, nextBorder);
+        newLane->SetBorder(laneMidBorderType, newLaneBorder);
         newLane->SetBorder( FPLATEAURnLaneBorderTypeEx::GetOpposite(laneMidBorderType), midBorderWay);
         if (lane->IsMedianLane()) {
             newNextRoad->SetMedianLane(newLane);
@@ -764,10 +769,15 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
 
     newNextRoad->SetPrevNext(Road, Road->GetNext());
     Road->SetPrevNext(Road->GetPrev(), newNextRoad);
-    if(newNextRoad->GetPrev())
-        newNextRoad->GetPrev()->ReplaceNeighbor(Road, newNextRoad);
-    if (newNextRoad->GetNext())
-        newNextRoad->GetNext()->ReplaceNeighbor(Road, newNextRoad);
+
+    // next側は新しく道路か挿入されるので,参照情報もroad -> newNextRoadに置き換え
+    // prev側は元の道路のままなので差し替える必要はなし
+    if(newNextRoad->GetNext())
+    {
+        for(auto B : OldNextBorders)
+            newNextRoad->GetNext()->ReplaceNeighbor(B, newNextRoad);
+    }
+
     AddRoad(newNextRoad);
 
     // 歩道周りを処理する
@@ -783,12 +793,7 @@ URnModel::FSliceRoadHorizontalResult URnModel::SliceRoadHorizontal(URnRoad* Road
 
 void URnModel::SeparateContinuousBorder()
 {
-    for(auto inter : Intersections) {
-        // 連続した境界線を分離する
-        inter->SeparateContinuousBorder();
-    }
-
-    for(auto road : Roads) {
-        road->SeparateContinuousBorder();
+    for(auto Road : Roads) {
+        Road->SeparateContinuousBorder();
     }
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoad.cpp
@@ -83,10 +83,6 @@ void URnRoad::Init(const TArray<TWeakObjectPtr<UPLATEAUCityObjectGroup>>& InTarg
     }
 }
 
-const TArray<TRnRef_T<URnLane>>& URnRoad::GetAllLanes() const {
-    return MainLanes;
-}
-
 TArray<TRnRef_T<URnLane>> URnRoad::GetAllLanesWithMedian() const {
     TArray<TRnRef_T<URnLane>> Lanes = MainLanes;
     if (MedianLane) {
@@ -140,11 +136,11 @@ bool URnRoad::TryGetLanes(TOptional<EPLATEAURnDir> Dir, TArray<TRnRef_T<URnLane>
 
 
 bool URnRoad::IsLeftLane(const TRnRef_T<URnLane>& Lane) const {
-    return Lane && !Lane->GetIsReverse();
+    return Lane && !Lane->GetIsReversed();
 }
 
 bool URnRoad::IsRightLane(const TRnRef_T<URnLane>& Lane) const {
-    return Lane && Lane->GetIsReverse();
+    return Lane && Lane->GetIsReversed();
 }
 
 EPLATEAURnDir URnRoad::GetLaneDir(const TRnRef_T<URnLane>& Lane) const {
@@ -401,7 +397,7 @@ void URnRoad::Reverse(bool KeepOneLaneIsLeft)
     // 各レーンのWayの向きは変えずにIsRevereだけ変える
     // 左車線/右車線の関係が変わるので配列の並びも逆にする
     for (auto& Lane : GetAllLanesWithMedian()) {
-        Lane->SetIsReverse(!Lane->GetIsReverse());
+        Lane->SetIsReversed(!Lane->GetIsReversed());
     }
     Algo::Reverse(MainLanes);
     for (auto& Sw : GetSideWalks())

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadBase.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadBase.cpp
@@ -184,8 +184,8 @@ void URnRoadBase::MergeSamePointLineStrings() {
 
     // 各 Way に対して処理を行う
     for (URnWay* Way : Ways) {
-        // URnWay が TArray<FVector> 型の Points メンバーを持つとする
-        auto Points = Way->GetPoints().ToArray();
+        // LineStringのキャッシュなのでLineStringのPointsをキーにする
+        auto Points = Way->LineString->GetPoints();
 
         bool bIsCached = false;
         bool bIsReversed = false;
@@ -198,9 +198,19 @@ void URnRoadBase::MergeSamePointLineStrings() {
         // キャッシュが存在する場合、Way の LineString を更新する
         if (bIsCached) {
             Way->LineString = LS;
-            if (Way->IsReversed != bIsReversed) {
+            if (bIsReversed) {
                 Way->Reverse(true);
             }
         }
     }
+}
+
+bool URnRoadBase::Check()
+{
+    for(auto Sw : GetSideWalks())
+    {
+        if ( Sw && Sw->Check() == false)
+            return false;
+    }
+    return true;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -187,7 +187,7 @@ bool URnRoadGroup::IsDeepAligned() const {
             auto NowLane = NowLanes[j];
             auto PrevLane = PrevLanes[j];
 
-            if (!PrevLane->GetIsReverse()) {
+            if (!PrevLane->GetIsReversed()) {
                 if (!NowLane->GetPrevBorder()->IsSameLineReference(PrevLane->GetNextBorder())) {
                     UE_LOG(LogTemp, Error, TEXT("Invalid Direction Lane[%d]"), j);
                     return false;
@@ -473,7 +473,7 @@ void URnRoadGroup::AdjustBorder() {
         DuplicatePoints(RightWay->GetPoint(LastPointIndex), BorderLeft2Right.GetEnd());
 
         auto AdjustWay = [&](TRnRef_T<URnLane> Lane, TRnRef_T<URnWay> Way) {
-            if (Lane->GetIsReverse())
+            if (Lane->GetIsReversed())
                 Way = Way->ReversedWay();
             auto P = Way->GetPoint(LastPointIndex);
             auto N = BorderLeft2Right.GetNearestPoint(P->Vertex);

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -242,27 +242,11 @@ bool URnRoadGroup::MergeRoads() {
     auto DstRoad = (Roads)[0];
     auto DstLanes = DstRoad->GetAllLanesWithMedian();
     // 配列はコピーして持つ
-    auto DstSideWalks = DstRoad->GetSideWalks();
     for (int32 i = 1; i < Roads.Num(); i++) {
         // マージ元の道路. DstRoadに統合されて消える
         auto SrcRoad = (Roads)[i];
         auto SrcLanes = SrcRoad->GetAllLanesWithMedian();
 
-        // SideWalksと共通のLineStringがあるとき, レーン側は統合されるけど
-        // SideWalksは統合されない場合もある. その時はLineStringを分離する必要があるので
-        // 元のLineStringをコピーして持っておく
-        auto OriginalDstSideWalks = DstSideWalks;
-        TMap<TRnRef_T<URnWay>, TRnRef_T<URnWay>> Original;
-        for (const auto& SideWalk : DstSideWalks) {
-            for (const auto& Way : SideWalk->GetSideWays()) {
-                if (Way) {
-                    Original.Add(Way, Way->Clone(false));
-                }
-            }
-        }
-
-        // SideWalksと共通のLineStringもあるので2回追加しないように記録しておく
-        TSet<TRnRef_T<URnLineString>> Visited;
         for (int32 j = 0; j < SrcLanes.Num(); ++j) {
             auto SrcLane = SrcLanes[j];
             auto DstLane = DstLanes[j];
@@ -272,12 +256,11 @@ bool URnRoadGroup::MergeRoads() {
                 if(DstLane->GetLeftWay())
                 {
                     DstLane->GetLeftWay()->AppendBack2LineString(SrcLane->GetLeftWay());
-                    Visited.Add(DstLane->GetLeftWay()->LineString);                    
                 }
+                // 中間のレーンはつながっているので右車線に追加するのは最後だけで良い
                 if (j == SrcLanes.Num() - 1) {
                     if (DstLane->GetRightWay()) {
                         DstLane->GetRightWay()->AppendBack2LineString(SrcLane->GetRightWay());
-                        Visited.Add(DstLane->GetRightWay()->LineString);
                     }
                 }
 
@@ -288,12 +271,11 @@ bool URnRoadGroup::MergeRoads() {
                 if(DstLane->GetRightWay())
                 {
                     DstLane->GetRightWay()->AppendFront2LineString(SrcLane->GetRightWay());
-                    Visited.Add(DstLane->GetRightWay()->LineString);                    
                 }
+                // 中間のレーンはつながっているので右車線に追加するのは最後だけで良い
                 if (j == SrcLanes.Num() - 1) {
                     if (DstLane->GetLeftWay()) {
                         DstLane->GetLeftWay()->AppendFront2LineString(SrcLane->GetLeftWay());
-                        Visited.Add(DstLane->GetLeftWay()->LineString);
                     }
                 }
 
@@ -302,81 +284,10 @@ bool URnRoadGroup::MergeRoads() {
         }
 
         auto SrcSideWalks = SrcRoad->GetSideWalks();
-        TSet<TRnRef_T<URnSideWalk>> MergedDstSideWalks;
-
         for (const auto& SrcSw : SrcSideWalks) {
-            bool Found = false;
-            for (const auto& DstSw : DstSideWalks) {
-                auto MergeSideWalk = [&](bool Reverse, const TFunction<void(TRnRef_T<URnWay>, TRnRef_T<URnWay>)>& Merger) {
-                    auto InSideWay = Reverse ? SrcSw->GetInsideWay()->ReversedWay() : SrcSw->GetInsideWay();
-                    auto OutsideWay = Reverse ? SrcSw->GetOutsideWay()->ReversedWay() : SrcSw->GetOutsideWay();
-
-                    if (DstSw->GetInsideWay()) {
-                        if (!Visited.Contains(DstSw->GetInsideWay()->LineString)) {
-                            Merger(DstSw->GetInsideWay(), InSideWay);
-                            Visited.Add(DstSw->GetInsideWay()->LineString);
-                        }
-                        InSideWay = DstSw->GetInsideWay();
-                    }
-
-                    if (DstSw->GetOutsideWay()) {
-                        if (!Visited.Contains(DstSw->GetOutsideWay()->LineString)) {
-                            Merger(DstSw->GetOutsideWay(), OutsideWay);
-                            Visited.Add(DstSw->GetOutsideWay()->LineString);
-                        }
-                        OutsideWay = DstSw->GetOutsideWay();
-                    }
-
-                    DstSw->SetSideWays(OutsideWay, InSideWay);
-                    MergedDstSideWalks.Add(DstSw);
-                    Found = true;
-                    };
-
-                // start - startで重なっている場合
-                if (DstSw->GetStartEdgeWay() && SrcSw->GetStartEdgeWay() && DstSw->GetStartEdgeWay()->IsSameLineReference(SrcSw->GetStartEdgeWay())) {
-                    MergeSideWalk(true, [](TRnRef_T<URnWay> A, TRnRef_T<URnWay> B) { A->AppendFront2LineString(B); });
-                    DstSw->SetStartEdgeWay(SrcSw->GetEndEdgeWay());
-                }
-                // start - endで重なっている場合
-                else if (DstSw->GetStartEdgeWay() && SrcSw->GetEndEdgeWay() && DstSw->GetStartEdgeWay()->IsSameLineReference(SrcSw->GetEndEdgeWay())) {
-                    MergeSideWalk(false, [](TRnRef_T<URnWay> A, TRnRef_T<URnWay> B) { A->AppendFront2LineString(B); });
-                    DstSw->SetStartEdgeWay(SrcSw->GetStartEdgeWay());
-                }
-                // end - endで重なっている場合
-                else if (DstSw->GetEndEdgeWay() && SrcSw->GetEndEdgeWay() && DstSw->GetEndEdgeWay()->IsSameLineReference(SrcSw->GetEndEdgeWay())) {
-                    MergeSideWalk(true, [](TRnRef_T<URnWay> A, TRnRef_T<URnWay> B) { A->AppendBack2LineString(B); });
-                    DstSw->SetEndEdgeWay(SrcSw->GetStartEdgeWay());
-                }
-                // end - startで重なっている場合
-                else if (DstSw->GetEndEdgeWay() && SrcSw->GetStartEdgeWay() && DstSw->GetEndEdgeWay()->IsSameLineReference(SrcSw->GetStartEdgeWay())) {
-                    MergeSideWalk(false, [](TRnRef_T<URnWay> A, TRnRef_T<URnWay> B) { A->AppendBack2LineString(B); });
-                    DstSw->SetEndEdgeWay(SrcSw->GetEndEdgeWay());
-                }
-
-                if (Found) break;
-            }
-
-            // マージできなかった歩道は直接追加
-            if (!Found) {
-                SrcSw->SetSideWays(SrcSw->GetOutsideWay(), SrcSw->GetInsideWay());
-                DstRoad->AddSideWalk(SrcSw);
-                DstSideWalks.Add(SrcSw);
-            }
+            DstRoad->AddSideWalk(SrcSw);
         }
-
-        // DstSideWalksの中でマージされなかった(元の形状から変更されない)ものは
-        // レーンと共通のLineStringを持っている場合に勝手に形状変わっているかもしれないので明示的に元に戻す
-        for (const auto& Sw : OriginalDstSideWalks) {
-            if (!MergedDstSideWalks.Contains(Sw)) 
-            {
-                auto OutsideWay = Sw->GetOutsideWay();
-                auto InsideWay = Sw->GetInsideWay();
-                // 必ず辞書に存在するはず. 無い場合は例外で良い
-                Sw->SetSideWays(
-                    Sw->GetOutsideWay() ? Original[OutsideWay] : nullptr,
-                    Sw->GetInsideWay() ? Original[InsideWay] : nullptr);
-            }
-        }
+        DstRoad->MergeSamePointLineStrings();
 
         DstRoad->AddTargetTrans(SrcRoad->GetTargetTrans());
         SrcRoad->DisConnect(true);
@@ -393,6 +304,7 @@ bool URnRoadGroup::MergeRoads() {
                 UE_LOG(LogTemp, Error, TEXT("Failed to link edge"));
         }
     }
+    DstRoad->MergeSamePointLineStrings();
     DstRoad->SetPrevNext(PrevIntersection, NextIntersection);
 
     Roads.Reset();
@@ -506,7 +418,7 @@ void URnRoadGroup::AdjustBorder() {
             NewBorders.Add(RnNew<URnWay>(Ls));
         }
 
-        Inter->ReplaceEdges(Road, NewBorders);
+        Inter->ReplaceEdges(Road, BorderType, NewBorders);
         for (int32 i = 0; i < Lanes.Num(); ++i) {
             auto B = NewBorders[i];
             auto Lane = Lanes[i];
@@ -602,13 +514,13 @@ void URnRoadGroup::SetLaneCountWithoutMedian(int32 LeftCount, int32 RightCount, 
 
         if (i == Roads.Num() - 1) {
             if(NextIntersection)
-                NextIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
+                NextIntersection->ReplaceEdges(Road, EPLATEAURnLaneBorderType::Next, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
             NewNextBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
         }
 
         if (i == 0) {
             if(PrevIntersection)
-                PrevIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
+                PrevIntersection->ReplaceEdges(Road, EPLATEAURnLaneBorderType::Prev, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
             NewPrevBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
         }
 
@@ -675,12 +587,12 @@ void URnRoadGroup::SetLaneCountWithMedian(int32 LeftCount, int32 RightCount, flo
 
         if (i == Roads.Num() - 1 && NextIntersection)
         {
-            NextIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select( Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
+            NextIntersection->ReplaceEdges(Road, EPLATEAURnLaneBorderType::Next, FPLATEAURnLinq::Select( Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder(); }));
             NewNextBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetNextBorder()->LineString; }));
         }
 
         if (i == 0 && PrevIntersection) {
-            PrevIntersection->ReplaceEdges(Road, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
+            PrevIntersection->ReplaceEdges(Road, EPLATEAURnLaneBorderType::Prev, FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder(); }));
             NewPrevBorders.Append(FPLATEAURnLinq::Select(Lanes, [](const TRnRef_T<URnLane>& Lane) { return Lane->GetPrevBorder()->LineString; }));
         }
 

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnRoadGroup.cpp
@@ -253,32 +253,20 @@ bool URnRoadGroup::MergeRoads() {
 
             // 順方向(左車線)
             if (SrcRoad->IsLeftLane(SrcLane)) {
-                if(DstLane->GetLeftWay())
-                {
-                    DstLane->GetLeftWay()->AppendBack2LineString(SrcLane->GetLeftWay());
-                }
-                // 中間のレーンはつながっているので右車線に追加するのは最後だけで良い
-                if (j == SrcLanes.Num() - 1) {
-                    if (DstLane->GetRightWay()) {
-                        DstLane->GetRightWay()->AppendBack2LineString(SrcLane->GetRightWay());
-                    }
-                }
 
+                auto MergedLeftWay = URnWay::CreateMergedWay(DstLane->GetLeftWay(), SrcLane->GetLeftWay());
+                auto MergedRightWay = URnWay::CreateMergedWay(DstLane->GetRightWay(), SrcLane->GetRightWay());
+                DstLane->SetSideWay(EPLATEAURnDir::Left, MergedLeftWay);
+                DstLane->SetSideWay(EPLATEAURnDir::Right, MergedRightWay);
                 DstLane->SetBorder(EPLATEAURnLaneBorderType::Next, SrcLane->GetNextBorder());
             }
             // 逆方向(右車線)
             else {
-                if(DstLane->GetRightWay())
-                {
-                    DstLane->GetRightWay()->AppendFront2LineString(SrcLane->GetRightWay());
-                }
-                // 中間のレーンはつながっているので右車線に追加するのは最後だけで良い
-                if (j == SrcLanes.Num() - 1) {
-                    if (DstLane->GetLeftWay()) {
-                        DstLane->GetLeftWay()->AppendFront2LineString(SrcLane->GetLeftWay());
-                    }
-                }
 
+                auto MergedLeftWay = URnWay::CreateMergedWay(SrcLane->GetLeftWay(), DstLane->GetLeftWay());
+                auto MergedRightWay = URnWay::CreateMergedWay(SrcLane->GetRightWay(),DstLane->GetRightWay());
+                DstLane->SetSideWay(EPLATEAURnDir::Left, MergedLeftWay);
+                DstLane->SetSideWay(EPLATEAURnDir::Right, MergedRightWay);               
                 DstLane->SetBorder(EPLATEAURnLaneBorderType::Prev, SrcLane->GetPrevBorder());
             }
         }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnSideWalk.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnSideWalk.cpp
@@ -14,6 +14,19 @@ URnSideWalk::URnSideWalk()
 void URnSideWalk::Init()
 {}
 
+void URnSideWalk::Init(const TRnRef_T<URnRoadBase>& Parent, const TRnRef_T<URnWay>& InOutsideWay,
+    const TRnRef_T<URnWay>& InInsideWay, const TRnRef_T<URnWay>& InStartEdgeWay, const TRnRef_T<URnWay>& InEndEdgeWay,
+    EPLATEAURnSideWalkLaneType InLaneType)
+{
+    this->ParentRoad = Parent;
+    this->OutsideWay = InOutsideWay;
+    this->InsideWay = InInsideWay;
+    this->StartEdgeWay = InStartEdgeWay;
+    this->EndEdgeWay = InEndEdgeWay;
+    this->LaneType = InLaneType;
+    this->Align();
+}
+
 TRnRef_T<URnRoadBase> URnSideWalk::GetParentRoad() const
 { return RnFrom(ParentRoad); }
 
@@ -54,22 +67,16 @@ void URnSideWalk::SetParent(const TRnRef_T<URnRoadBase>& InParent) {
     ParentRoad = InParent;
 }
 
-void URnSideWalk::UnLinkFromParent() {
-    if (GetParentRoad()) {
-        GetParentRoad()->RemoveSideWalk(TRnRef_T<URnSideWalk>(this));
-    }
-}
-
 void URnSideWalk::SetSideWays(const TRnRef_T<URnWay>& InOutsideWay, const TRnRef_T<URnWay>& InInsideWay) {
     OutsideWay = InOutsideWay;
     InsideWay = InInsideWay;
-    TryAlign();
+    Align();
 }
 
 void URnSideWalk::SetEdgeWays(const TRnRef_T<URnWay>& StartWay, const TRnRef_T<URnWay>& EndWay) {
     StartEdgeWay = StartWay;
     EndEdgeWay = EndWay;
-    TryAlign();
+    Align();
 }
 
 void URnSideWalk::SetStartEdgeWay(const TRnRef_T<URnWay>& StartWay) {
@@ -87,7 +94,7 @@ void URnSideWalk::ReverseLaneType() {
         LaneType = EPLATEAURnSideWalkLaneType::LeftLane;
 }
 
-void URnSideWalk::TryAlign() {
+void URnSideWalk::Align() {
     auto AlignWay = [this](const TRnRef_T<URnWay>& Way) {
         if (!Way || !Way->IsValid()) return;
 
@@ -132,17 +139,10 @@ TRnRef_T<URnSideWalk> URnSideWalk::Create(
     const TRnRef_T<URnWay>& InsideWay,
     const TRnRef_T<URnWay>& StartEdgeWay,
     const TRnRef_T<URnWay>& EndEdgeWay,
-    EPLATEAURnSideWalkLaneType LaneType) {
-    auto SideWalk = RnNew<URnSideWalk>();
-    SideWalk->ParentRoad = Parent;
-    SideWalk->OutsideWay = OutsideWay;
-    SideWalk->InsideWay = InsideWay;
-    SideWalk->StartEdgeWay = StartEdgeWay;
-    SideWalk->EndEdgeWay = EndEdgeWay;
-    SideWalk->LaneType = LaneType;
-    SideWalk->TryAlign();
-
-    if (Parent) {
+    EPLATEAURnSideWalkLaneType LaneType,
+    bool AddToParent) {
+    auto SideWalk = RnNew<URnSideWalk>(Parent, OutsideWay, InsideWay, StartEdgeWay, EndEdgeWay, LaneType);
+    if (AddToParent && Parent) {
         Parent->AddSideWalk(SideWalk);
     }
 
@@ -202,4 +202,97 @@ float URnSideWalk::CalcRoadProximityScore(const TRnRef_T<URnRoadBase>& Other) co
     }
 
     return -1.f;
+}
+
+// Reverse
+// StartEdgeWay と EndEdgeWay を入れ替え、Align を呼び出す
+void URnSideWalk::Reverse() {
+    Swap(StartEdgeWay, EndEdgeWay);
+    Align();
+}
+
+
+// ReversedSideWalk
+// 現在の情報をもとに新しい URnSideWalk インスタンスを生成し、Reverse を実行して返す
+URnSideWalk* URnSideWalk::ReversedSideWalk() {
+    // 親への追加は行わないようにする
+    auto Copy = [](URnWay* W) {
+        return W ? W->ShallowClone() : nullptr;
+        };
+    URnSideWalk* NewSideWalk = Create(ParentRoad.Get()
+        , Copy(OutsideWay)
+        , Copy(InsideWay)
+        , Copy(StartEdgeWay)
+        , Copy(EndEdgeWay)
+        , LaneType
+        , false);
+    // Align 済みの状態で、反転処理を行う
+    NewSideWalk->Reverse();
+    return NewSideWalk;
+}
+
+// TryMergeNeighborSideWalk
+// 隣接する歩道との統合を試み、統合できた場合は true を返す
+bool URnSideWalk::TryMergeNeighborSideWalk(URnSideWalk* SrcSideWalk) {
+
+    if (SrcSideWalk == nullptr) {
+        return false;
+    }
+    // 両方の歩道について、方向合わせの処理
+    Align();
+    SrcSideWalk->Align();
+
+    // IsMatch: 2 つの URnWay が同一の線分を参照しているか
+    auto IsMatch = [](URnWay* A, URnWay* B) -> bool {
+        return (A != nullptr && B != nullptr && A->IsSameLineReference(B));
+        };
+
+    // MergeSideWays: src 側の SideWay と dst 側の SideWay を統合するラムダ
+    auto MergeSideWays = [](URnSideWalk* SrcSw, URnSideWalk* DstSw) {
+#if true
+        // #TODO : 現状の使い方だと問題ないが, 今後OutsideWay同士, InsideWay同士が繋がっているかの保証が無いのでポイント単位でチェックすべき
+        if (SrcSw && DstSw) {
+            // URnWay::CreateMergedWay は、2 つの URnWay を統合して新たな URnWay を生成する静的メソッドと想定
+            DstSw->SetSideWays(
+                URnWay::CreateMergedWay(SrcSw->GetOutsideWay(), DstSw->GetOutsideWay(), false),
+                URnWay::CreateMergedWay(SrcSw->GetInsideWay(), DstSw->GetInsideWay(), false)
+            );
+            // 始点側の Edge は、src 側のものに切り替える
+            DstSw->SetStartEdgeWay(SrcSw->GetStartEdgeWay());
+        }
+#endif
+        };
+
+    // 以下、各ケースについて、隣接部分が一致する場合の処理
+
+    // ケース1: 自身の StartEdgeWay と SrcSideWalk の StartEdgeWay が一致
+    if (IsMatch(GetStartEdgeWay(), SrcSideWalk->GetStartEdgeWay())) {
+        // SrcSideWalk 側を反転して統合する
+        URnSideWalk* Rev = SrcSideWalk->ReversedSideWalk();
+        MergeSideWays(Rev, this);
+        return true;
+    }
+    // ケース2: 自身の StartEdgeWay と SrcSideWalk の EndEdgeWay が一致
+    else if (IsMatch(GetStartEdgeWay(), SrcSideWalk->GetEndEdgeWay())) {
+        MergeSideWays(SrcSideWalk, this);
+        return true;
+    }
+    // ケース3: 自身の EndEdgeWay と SrcSideWalk の EndEdgeWay が一致
+    else if (IsMatch(GetEndEdgeWay(), SrcSideWalk->GetEndEdgeWay())) {
+        // 自身を一旦反転してから統合、統合後再反転
+        Reverse();
+        MergeSideWays(SrcSideWalk, this);
+        Reverse();
+        return true;
+    }
+    // ケース4: 自身の EndEdgeWay と SrcSideWalk の StartEdgeWay が一致
+    else if (IsMatch(GetEndEdgeWay(), SrcSideWalk->GetStartEdgeWay())) {
+        Reverse();
+        URnSideWalk* Rev = SrcSideWalk->ReversedSideWalk();
+        MergeSideWays(Rev, this);
+        Reverse();
+        return true;
+    }
+
+    return false;
 }

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnSideWalk.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnSideWalk.cpp
@@ -249,7 +249,6 @@ bool URnSideWalk::TryMergeNeighborSideWalk(URnSideWalk* SrcSideWalk) {
 
     // MergeSideWays: src 側の SideWay と dst 側の SideWay を統合するラムダ
     auto MergeSideWays = [](URnSideWalk* SrcSw, URnSideWalk* DstSw) {
-#if true
         // #TODO : 現状の使い方だと問題ないが, 今後OutsideWay同士, InsideWay同士が繋がっているかの保証が無いのでポイント単位でチェックすべき
         if (SrcSw && DstSw) {
             // URnWay::CreateMergedWay は、2 つの URnWay を統合して新たな URnWay を生成する静的メソッドと想定
@@ -260,7 +259,6 @@ bool URnSideWalk::TryMergeNeighborSideWalk(URnSideWalk* SrcSideWalk) {
             // 始点側の Edge は、src 側のものに切り替える
             DstSw->SetStartEdgeWay(SrcSw->GetStartEdgeWay());
         }
-#endif
         };
 
     // 以下、各ケースについて、隣接部分が一致する場合の処理

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnSideWalk.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnSideWalk.cpp
@@ -294,3 +294,36 @@ bool URnSideWalk::TryMergeNeighborSideWalk(URnSideWalk* SrcSideWalk) {
 
     return false;
 }
+
+bool URnSideWalk::Check() const
+{
+    auto IsContinuous = [this](URnWay* A, URnWay* B) {
+        if (A == nullptr || B == nullptr)
+            return true;
+        auto Av0 = A->GetPoint(0);
+        auto Av1 = A->GetPoint(-1);
+
+        auto Bv0 = B->GetPoint(0);
+        auto Bv1 = B->GetPoint(-1);
+        return (Av0 == Bv0 || Av0 == Bv1) || (Av1 == Bv0 || Av1 == Bv1);
+        };
+    if (IsContinuous(GetInsideWay(), GetStartEdgeWay()) == false) {
+        UE_LOG(LogTemp, Error, TEXT("InsideWayとStartEdgeWayが端点で繋がっていません. %s"), *GetName());
+        return false;
+    }
+    if (IsContinuous(GetInsideWay(), GetEndEdgeWay()) == false) {
+        UE_LOG(LogTemp, Error, TEXT("InsideWayとEndEdgeWayが端点で繋がっていません. %s"), *GetName());
+        return false;
+
+    }
+    if (IsContinuous(GetOutsideWay(), GetStartEdgeWay()) == false) {
+        UE_LOG(LogTemp, Error, TEXT("OutsideWayとStartEdgeWayが端点で繋がっていません. %s"), *GetName());
+        return false;
+    }
+    if (IsContinuous(GetOutsideWay(), GetEndEdgeWay()) == false) {
+        UE_LOG(LogTemp, Error, TEXT("OutsideWayとEndEdgeWayが端点で繋がっていません. %s"), *GetName());
+        return false;
+
+    }
+    return true;
+}

--- a/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnWay.cpp
+++ b/Source/PLATEAURuntime/Private/RoadNetwork/Structure/RnWay.cpp
@@ -361,7 +361,12 @@ void URnWay::Move(const FVector& Offset) {
 
 TRnRef_T<URnWay> URnWay::Clone(bool CloneVertex) const
 {
-    return RnNew<URnWay>(LineString->Clone(CloneVertex), IsReversed, IsReverseNormal);
+    return Create(LineString->Clone(CloneVertex), IsReversed, IsReverseNormal);
+}
+
+TRnRef_T<URnWay> URnWay::ShallowClone() const
+{
+    return Create(LineString, IsReversed, IsReverseNormal);
 }
 
 bool URnWay::IsSameLineReference(const URnWay* Other) const {
@@ -429,6 +434,29 @@ TArray<TRnRef_T<URnWay>> URnWay::Split(int32 Num, bool InsertNewPoint, TFunction
     return Result;
 }
 
+TRnRef_T<URnWay> URnWay::Create(const TRnRef_T<URnLineString>& InLineString, bool bInIsReversed, bool bInIsReverseNormal)
+{
+    return RnNew<URnWay>(InLineString, bInIsReversed, bInIsReverseNormal);
+}
+
+TRnRef_T<URnWay> URnWay::CreateMergedWay(URnWay* A, URnWay* B, bool RemoveDuplicate)
+{
+    TArray<URnPoint*> Points;
+    if(A)
+    {
+        for (auto P : A->GetPoints())
+            Points.Add(P);
+    }
+
+    if(B)
+    {
+        for (auto P : B->GetPoints())
+            Points.Add(P);
+    }
+    auto Ls = URnLineString::Create(Points, RemoveDuplicate);
+    return Create(Ls, false, false);
+}
+
 bool FRnWayEx::TryMergePointsToLineString(URnWay* Self, URnWay* Src, float PointDistanceTolerance) {
     if (Self->GetPoint(0)->IsSamePoint(Src->GetPoint(0), PointDistanceTolerance)) {
         Self->AppendFront2LineString(Src->ReversedWay());
@@ -447,4 +475,11 @@ bool FRnWayEx::TryMergePointsToLineString(URnWay* Self, URnWay* Src, float Point
     }
 
     return true;
+}
+
+TRnRef_T<URnWay> FRnWayEx::ShallowCloneOrDefault(URnWay* Self)
+{
+    if (!Self)
+        return nullptr;
+    return Self->ShallowClone();
 }

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/PLATEAURGraph.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/PLATEAURGraph.h
@@ -141,6 +141,9 @@ public:
     FLinearColor SideWalkColor;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    FLinearColor MedianColor;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     FLinearColor HighWayColor;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphEx.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphEx.h
@@ -92,4 +92,17 @@ public:
     {
         return FPLATEAURnEx::GroupByOutlineEdges<T, RGraphRef_t<UREdge>>(OutlineEdges, KeySelector);
     }
+
+    /**
+     * FaceReduction
+     *
+     * URGraph に含まれる Face 同士のうち、Edge 数ごとにグループ化し、
+     * 同じ Edge 群を持つ Face (すなわち、f1 のすべての Edge が f2 に含まれる場合)
+     * を f2 -> f1 の順にマージします。マージに成功した場合は対象 Face をグループから除去し、
+     * マージされた Face 数を返します。
+     *
+     * @param Graph マージ対象の URGraph オブジェクト
+     * @return マージにより削除された Face の数
+     */
+    static int32 FaceReduction(URGraph* Graph);
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphFactory.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/RGraph/RGraphFactory.h
@@ -51,6 +51,10 @@ public:
 
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
     bool bOptModifySideWalkShape = true;
+
+    // 全く同じ辺を持つFaceを統合する
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "PLATEAU|Factory|Optimize")
+    bool bFaceReduction = true;
 };
 
 struct FRGraphFactoryEx

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
@@ -143,7 +143,10 @@ struct FRnModelDrawRoadNormalOption : public FRnModelDrawOption {
     GENERATED_BODY()
 public:
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
-    bool bShowSpline = true;
+    bool bShowNextConnection = false;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    bool bShowPrevConnection = false;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     int ShowLaneIndex = -1;
@@ -194,6 +197,11 @@ public:
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     bool bCheckSliceHorizontal = false;
 
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    EPLATEAURnLaneBorderType CheckSliceHorizontalDir = EPLATEAURnLaneBorderType::Next;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    float CheckSliceHorizontalOffset = 200.f;
 };
 
 USTRUCT()
@@ -248,6 +256,10 @@ public:
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     FRnModelDrawWayOption ShowEndEdgeWay;
+
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    bool bCheck;
 };
 
 USTRUCT()

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
@@ -189,6 +189,9 @@ public:
     bool bMerge2Intersection = false;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    bool bMergeRoadGroup = false;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     bool bCheckSliceHorizontal = false;
 
 };
@@ -297,6 +300,12 @@ public:
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     TArray<FString> ShowTargetNames;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    bool bShowOnlyTargetTrans = false;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    TArray<FString> ShowTargetTranNames;
 
     void Draw(URnModel* Model);
 };

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/PLATEAURnModelDrawerDebug.h
@@ -186,6 +186,9 @@ public:
     bool bSliceHorizontal = false;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
+    bool bMerge2Intersection = false;
+
+    UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     bool bCheckSliceHorizontal = false;
 
 };
@@ -229,6 +232,8 @@ USTRUCT()
 struct FRnModelDrawSideWalkOption : public FRnModelDrawOption {
     GENERATED_BODY()
 public:
+
+    FRnModelDrawSideWalkOption();
     UPROPERTY(EditAnywhere, Category = "PLATEAU|Debug")
     FRnModelDrawWayOption ShowOutsideWay;
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnIntersection.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnIntersection.h
@@ -2,7 +2,6 @@
 
 #include "CoreMinimal.h"
 #include "RnRoadBase.h"
-#include "RnWay.h"
 #include "RoadNetwork/PLATEAURnDef.h"
 #include "RoadNetwork/Util/PLATEAURnEx.h"
 #include "RnIntersection.generated.h"
@@ -13,7 +12,7 @@ class UPLATEAUCityObjectGroup;
 class URnRoadBase;
 class URnWay;
 class URnRoad;
-
+struct FBuildTrackOption;
 UENUM(BlueprintType)
 enum class ERnTurnType : uint8 {
     LeftBack   UMETA(DisplayName = "左後ろ"),
@@ -210,23 +209,29 @@ public:
     void RemoveEdges(const TRnRef_T<URnRoadBase>& Road);
 
     // 指定したRoadに接続されているEdgeを削除
-    void RemoveEdges(const TFunction<bool(const TRnRef_T<URnIntersectionEdge>&)>& Predicate);
+    int32 RemoveEdges(const TFunction<bool(const TRnRef_T<URnIntersectionEdge>&)>& Predicate);
+
+    /*
+     * 指定した境界線をエッジから削除する
+     */
+    int32 RemoveEdges(const TRnRef_T<URnWay>& Way);
 
     // 指定したRoadに接続されているEdgeを置き換える
-    void ReplaceEdges(const TRnRef_T<URnRoadBase>& Road, const TArray<TRnRef_T<URnWay>>& NewBorders);
+    void ReplaceEdges(const TRnRef_T<URnRoad>& Road, EPLATEAURnLaneBorderType BorderType, const TArray<TRnRef_T<URnWay>>& NewBorders);
 
     // borderを持つEdgeの隣接道路情報をafterRoadに差し替える.
     // 戻り値は差し替えが行われた数
     int32 ReplaceEdgeLink(TRnRef_T<URnWay> Border, TRnRef_T<URnRoadBase> AfterRoad);
 
-    // Edgeを追加
-    void AddEdge(const TRnRef_T<URnRoadBase>& Road, const TRnRef_T<URnWay>& Border);
+    // Edgeを追加(Border==nullptrの場合はfalseが返る)
+    bool AddEdge(const TRnRef_T<URnRoadBase>& Road, const TRnRef_T<URnWay>& Border);
 
     // 指定したRoadに接続されているかどうか
     bool HasEdge(const TRnRef_T<URnRoadBase>& Road) const;
 
     // 指定したRoadに接続されているかどうか
     bool HasEdge(const TRnRef_T<URnRoadBase>& Road, const TRnRef_T<URnWay>& Border) const;
+    bool IsAligned() const;
 
     // Edgesの順番を整列する
     // 各Edgeが連結かつ時計回りになるように整列する
@@ -266,6 +271,20 @@ public:
     virtual TRnRef_T<URnIntersection> CastToIntersection() override {
         return TRnRef_T<URnIntersection>(this);
     }
+    void SeparateContinuousBorder();
+
+    void BuildTracks();
+    void BuildTracks(const FBuildTrackOption& Option);
+    // 構造的に正しいかどうかチェック
+    virtual bool Check() override;
+    void MergeContinuousNonBorderEdge();
+
+    // ReplaceNeighbor(URnWay* borderWay, URnRoadBase* to)
+    // 指定した境界線（borderWay）に対応する隣接道路情報を to に置き換えます。
+    virtual void ReplaceNeighbor(URnWay* BorderWay, URnRoadBase* To) override;
+    // -------------------
+    // static関数
+    // -------------------
 
     // 交差点を作成する
     static TRnRef_T<URnIntersection> Create(TObjectPtr<UPLATEAUCityObjectGroup> TargetTran = nullptr);
@@ -276,9 +295,13 @@ public:
     /// </summary>
     /// <param name="edge"></param>
     static void AlignEdgeNormal(TRnRef_T<URnIntersectionEdge> edge);
-    void SeparateContinuousBorder();
 
-    void BuildTracks();
+
+private:
+    /*
+     * エッジの削除.関係するトラックも削除される
+     */
+    bool RemoveEdge(URnIntersectionEdge* Edge);
 
 private:
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
@@ -34,12 +34,12 @@ public:
 
     void SetParent(TRnRef_T<URnRoad> InParent);
 
-    bool GetIsReverse() const {
-        return bIsReverse;
+    bool GetIsReversed() const {
+        return bIsReversed;
     }
 
-    void SetIsReverse(bool bReverse) {
-        bIsReverse = bReverse;
+    void SetIsReversed(bool bReverse) {
+        bIsReversed = bReverse;
     }
 
     TRnRef_T<URnWay> GetLeftWay() const;
@@ -169,7 +169,7 @@ private:
 
     // 親Roadと逆方向(右車線等)
     UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
-    bool bIsReverse;
+    bool bIsReversed;
 
     // 内部的に持つだけ. 中心線
     UPROPERTY(VisibleAnywhere, Category = "PLATEAU")

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLane.h
@@ -129,6 +129,13 @@ public:
     TArray<TRnRef_T<URnRoadBase>> GetPrevRoads();
     TRnRef_T<URnRoadBase> GetNextRoad();
     TRnRef_T<URnRoadBase> GetPrevRoad();
+
+
+    /*
+     * 不正値チェック
+     */
+    bool Check();
+
     static TRnRef_T<URnLane> CreateOneWayLane(TRnRef_T<URnWay> way);
 
     /// <summary>

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLineString.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnLineString.h
@@ -15,6 +15,10 @@ UCLASS(ClassGroup = (Custom), BlueprintType, Blueprintable, meta = (BlueprintSpa
 class URnLineString : public UObject
 {
     GENERATED_BODY()
+private:
+    inline static constexpr float DefaultDistanceEpsilon = 0.f * FPLATEAURnDef::Meter2Unit;
+    inline static constexpr float DefaultDegEpsilon = 0.5f;
+    inline static constexpr float DefaultMidPointTolerance = 0.1f * FPLATEAURnDef::Meter2Unit;
 public:
     URnLineString();
     URnLineString(int32 InitialSize);
@@ -48,8 +52,8 @@ public:
     void GetNearestPoint(const FVector& Pos, FVector& OutNearest, float& OutPointIndex, float& OutDistance) const;
     float GetDistance2D(const TRnRef_T<URnLineString> Other, EAxisPlane Plane = EAxisPlane::Xy) const;
 
-    void AddPointOrSkip(TRnRef_T<URnPoint> Point, float DistanceEpsilon = 0.0f, float DegEpsilon = 0.5f, float MidPointTolerance = 0.3f);
-    void AddPointFrontOrSkip(TRnRef_T<URnPoint> Point, float DistanceEpsilon = 0.0f, float DegEpsilon = 0.5f, float MidPointTolerance = 0.3f);
+    void AddPointOrSkip(TRnRef_T<URnPoint> Point, float DistanceEpsilon = DefaultDistanceEpsilon, float DegEpsilon = DefaultDegEpsilon, float MidPointTolerance = DefaultMidPointTolerance);
+    void AddPointFrontOrSkip(TRnRef_T<URnPoint> Point, float DistanceEpsilon = DefaultDistanceEpsilon, float DegEpsilon = DefaultDegEpsilon, float MidPointTolerance = DefaultMidPointTolerance);
 
     FVector GetVertexNormal(int32 VertexIndex) const;
     FVector GetEdgeNormal(int32 StartVertexIndex) const;
@@ -65,10 +69,6 @@ public:
 
     TArray<FLineSegment2D> GetEdges2D(EAxisPlane axis = FPLATEAURnDef::Plane) const;
     TArray<FLineSegment3D> GetEdges() const;
-
-    static TRnRef_T<URnLineString> Create(const TArray<TRnRef_T<URnPoint>>& Vertices, bool RemoveDuplicate = true);
-    static TRnRef_T<URnLineString> Create(const TArray<FVector>& Vertices, bool RemoveDuplicate = true);
-    static bool Equals(const TRnRef_T<URnLineString> X, const TRnRef_T<URnLineString> Y);
 
     FVector operator[](int32 Index) const;
 
@@ -102,8 +102,44 @@ public:
     // selfの各点に対して, otherとの距離を出して, その平均をスコアとする
     TOptional<float> CalcProximityScore(const URnLineString* Other) const;
 
+    /*
+     * Static関数
+     */
+
+
+
+     /*
+      * 頂点リストから線分を生成する
+      * RemoveDuplicate : 重複する頂点を取り除くかのフラグ
+      */
+    static TRnRef_T<URnLineString> Create(const TArray<TRnRef_T<URnPoint>>& Vertices, float DistanceEpsilon, float DegEpsilon, float MidPointTolerance);
+
+    /*
+     * 頂点リストから線分を生成する
+     * RemoveDuplicate : 重複する頂点を取り除くかのフラグ
+     */
+    static TRnRef_T<URnLineString> Create(const TArray<TRnRef_T<URnPoint>>& Vertices, bool RemoveDuplicate = true);
+
+    /*
+     * 頂点リストから線分を生成する
+     * RemoveDuplicate : 重複する頂点を取り除くかのフラグ
+     */
+    static TRnRef_T<URnLineString> Create(const TArray<FVector>& Vertices, bool RemoveDuplicate = true);
+
+    static bool Equals(const TRnRef_T<URnLineString> X, const TRnRef_T<URnLineString> Y);
+
 private:
     UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
     TArray<URnPoint*> Points;
 };
 
+struct FRnLineStringEx
+{
+public:
+    static bool IsSequenceEqual(URnLineString* A, URnLineString* B, bool& OutIsReverse);
+
+    /*
+     * ポイントを共有しているかどうかを返す
+     */
+    static bool IsPointShared(const URnLineString* A, const URnLineString* B);
+};

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnModel.h
@@ -174,8 +174,11 @@ public:
     };
 
     struct FSliceRoadHorizontalResult {
+        // 切断結果
         ERoadCutResult Result;
+        // 元のRoadのPrev側(元のRoadはこれになる)
         URnRoad* PrevRoad;
+        // 元のRoadのNext側
         URnRoad* NextRoad;
     };
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -164,6 +164,8 @@ public:
     // 隣接情報を置き換える
     virtual void ReplaceNeighbor(const TRnRef_T<URnRoadBase>& From, const TRnRef_T<URnRoadBase>& To) override;
 
+    // 隣接情報を置き換える
+    virtual void ReplaceNeighbor(URnWay* BorderWay, URnRoadBase* To) override;
     // 左右のWayを結合したものを取得
     TArray<TRnRef_T<URnWay>> GetMergedSideWays() const;
     bool TryMerge2NeighborIntersection(EPLATEAURnLaneBorderType BorderType);
@@ -182,7 +184,7 @@ public:
     }
 
     // 構造的に正しいかどうかチェック
-    virtual bool Check() const override;
+    virtual bool Check() override;
 
 
     bool TryGetVerticalSliceSegment(

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -25,9 +25,6 @@ public:
     // メインレーンすべて取得
     const auto& GetMainLanes() const { return MainLanes; }
 
-    // 全レーン
-    const TArray<TRnRef_T<URnLane>>& GetAllLanes() const;
-
     // 中央分離帯を含めた全てのレーン
     TArray<TRnRef_T<URnLane>> GetAllLanesWithMedian() const;
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoad.h
@@ -102,11 +102,20 @@ public:
 
     /// <summary>
     /// #TODO : 左右の隣接情報がないので要修正
-    /// laneを追加する. ParentRoad情報も更新する
+    /// MainLanesにlaneを追加する. すでに存在する場合には無視される.ParentRoad情報も更新する
     /// </summary>
     /// <param name="Lane"></param>
-    void AddMainLane(TRnRef_T<URnLane> Lane);
+    bool AddMainLane(TRnRef_T<URnLane> Lane);
 
+    /*
+     * MainLanesのIndex位置にlaneを追加する. すでに存在する場合には無視される. ParentRoad情報も更新する
+     */
+    bool AddMainLane(TRnRef_T<URnLane> Lane, int32 Index);
+
+    /*
+     * MainLanesからLaneを削除. ParentRoad情報も更新する
+     */
+    bool RemoveMainLane(TRnRef_T<URnLane> Lane);
 
     // 指定した方向の境界線を取得する(全レーンマージした状態で取得する)
     TRnRef_T<URnWay> GetMergedBorder(EPLATEAURnLaneBorderType BorderType, TOptional<EPLATEAURnDir> Dir = NullOpt) const;
@@ -203,7 +212,8 @@ public:
 
 private:
 
-    void OnAddLane(TRnRef_T<URnLane> lane);
+    void OnAddLane(TRnRef_T<URnLane> Lane);
+    void OnRemoveLane(TRnRef_T<URnLane> Lane);
 
 public:
     // 接続先(nullの場合は接続なし)

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
@@ -82,10 +82,7 @@ public:
     void MergeSamePointLineStrings();
 
     // 構造的に正しいかどうかチェック
-    virtual bool Check()
-    {
-        return true;
-    }
+    virtual bool Check();
 
     // RnRoadへキャストする
     virtual TRnRef_T<URnRoad> CastToRoad()

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnRoadBase.h
@@ -25,7 +25,7 @@ public:
 
     // 歩道sideWalkを追加する
     // sideWalkの親情報も書き換える
-    void AddSideWalk(const TRnRef_T<URnSideWalk>& SideWalk);
+    bool AddSideWalk(const TRnRef_T<URnSideWalk>& SideWalk);
 
     // 歩道sideWalkを削除する
     // sideWalkの親情報は変更しない
@@ -76,9 +76,13 @@ public:
 
     TRnRef_T<URnModel> GetParentModel() const;
     void SetParentModel(const TRnRef_T<URnModel>& InParentModel);
+    bool RemoveSideWalk(URnSideWalk* InSideWalk, bool bRemoveFromModel);
+    void MergeConnectedSideWalks();
+    void MergeSideWalks(const TArray<URnSideWalk*>& AddSideWalks);
+    void MergeSamePointLineStrings();
 
     // 構造的に正しいかどうかチェック
-    virtual bool Check() const
+    virtual bool Check()
     {
         return true;
     }
@@ -94,6 +98,10 @@ public:
     {
         return nullptr;
     }
+
+    // ReplaceNeighbor(URnWay* borderWay, URnRoadBase* to)
+    // 指定した境界線（borderWay）に対応する隣接道路情報を to に置き換えます。
+    virtual void ReplaceNeighbor(URnWay* BorderWay, URnRoadBase* To) {}
 
 private:
 

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
@@ -96,10 +96,8 @@ public:
     URnSideWalk* ReversedSideWalk();
     bool TryMergeNeighborSideWalk(URnSideWalk* SrcSideWalk);
 
-    bool Check() const
-    {
-        return true;
-    }
+    bool Check() const;
+
 private:
     UPROPERTY(VisibleAnywhere, Category = "PLATEAU")
     TWeakObjectPtr<URnRoadBase> ParentRoad;

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnSideWalk.h
@@ -15,6 +15,14 @@ class URnSideWalk : public UObject {
 public:
     URnSideWalk();
     void Init();
+
+    void Init(
+        const TRnRef_T<URnRoadBase>& Parent,
+        const TRnRef_T<URnWay>& OutsideWay,
+        const TRnRef_T<URnWay>& InsideWay,
+        const TRnRef_T<URnWay>& StartEdgeWay,
+        const TRnRef_T<URnWay>& EndEdgeWay,
+        EPLATEAURnSideWalkLaneType LaneType = EPLATEAURnSideWalkLaneType::Undefined);
     // 自分が所属するRoadNetworkModel
     TRnRef_T<URnRoadBase> GetParentRoad() const;
 
@@ -50,9 +58,6 @@ public:
     // 強制的に親を変更する. 構造壊れるので扱い注意
     void SetParent(const TRnRef_T<URnRoadBase>& Parent);
 
-    // 親からのリンク解除
-    void UnLinkFromParent();
-
     // 左右のWayを再設定
     void SetSideWays(const TRnRef_T<URnWay>& OutsideWay, const TRnRef_T<URnWay>& InsideWay);
 
@@ -65,7 +70,7 @@ public:
     void ReverseLaneType();
 
     // InSideWay/OutSideWayの方向を合わせる
-    void TryAlign();
+    void Align();
 
     // 歩道作成
     static TRnRef_T<URnSideWalk> Create(
@@ -74,7 +79,10 @@ public:
         const TRnRef_T<URnWay>& InsideWay,
         const TRnRef_T<URnWay>& StartEdgeWay,
         const TRnRef_T<URnWay>& EndEdgeWay,
-        EPLATEAURnSideWalkLaneType LaneType = EPLATEAURnSideWalkLaneType::Undefined);
+        EPLATEAURnSideWalkLaneType LaneType = EPLATEAURnSideWalkLaneType::Undefined,
+        bool AddToParent = true
+    );
+
 
     // 代表点を取得
     FVector GetCentralVertex() const;
@@ -84,6 +92,9 @@ public:
 
     // 近接スコア計算
     float CalcRoadProximityScore(const TRnRef_T<URnRoadBase>& Other) const;
+    void Reverse();
+    URnSideWalk* ReversedSideWalk();
+    bool TryMergeNeighborSideWalk(URnSideWalk* SrcSideWalk);
 
     bool Check() const
     {

--- a/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnWay.h
+++ b/Source/PLATEAURuntime/Public/RoadNetwork/Structure/RnWay.h
@@ -58,6 +58,16 @@ public:
             return PointIterator(Way,  Way ?Way->Count() : 0);
         }
 
+        TArray<TRnRef_T<URnPoint>> ToArray() const {
+            TArray<TRnRef_T<URnPoint>> Result;
+            if (Way) {
+                for (int32 i = 0; i < Way->Count(); ++i) {
+                    Result.Add(Way->GetPoint(i));
+                }
+            }
+            return Result;
+        }
+
         const URnWay* Way;
     };
 
@@ -153,6 +163,11 @@ public:
 
     TRnRef_T<URnWay> Clone(bool CloneVertex) const;
 
+    /*
+     * 自身の浅いコピーを返す
+     */
+    TRnRef_T<URnWay> ShallowClone() const;
+
     TArray<FLineSegment2D> GetEdges2D() const;
 
     int32 FindPoint(const TRnRef_T<URnPoint>& Point) const;
@@ -193,6 +208,16 @@ public:
     // 自身をnum分割して返す. 分割できない(頂点空）の時は空リストを返す.
     // insertNewPoint=trueの時はselfにも新しい点を追加する
     TArray<TRnRef_T<URnWay>> Split(int32 Num, bool InsertNewPoint, TFunction<float(int32)> RateSelector = nullptr);
+
+    /*
+     * ファクトリメソッド
+     */
+    static TRnRef_T<URnWay> Create(const TRnRef_T<URnLineString>& InLineString, bool bInIsReversed = false, bool bInIsReverseNormal = false);
+
+    /*
+     * A,BをつなげたWayを作成する
+     */
+    static TRnRef_T<URnWay> CreateMergedWay(URnWay* A, URnWay* B, bool RemoveDuplicate = true);
 private:
     int32 ToRawIndex(int32 Index, bool AllowMinus = false) const;
     int32 SwitchIndex(int32 Index) const;
@@ -225,4 +250,10 @@ struct FRnWayEx
     // vn == v0'だと, srcをそのままselfの末尾に追加 (v0, v1, v2, v3...vn(v0'), v1', v2', v3'...vm')となる
     // selfとsrcの最初と最後のポイントを見て, どっちの方向に結合するかを決める
     static bool TryMergePointsToLineString(URnWay* Self, URnWay* Src, float PointDistanceTolerance);
+
+
+    /*
+     * 自身の浅いコピーを返す
+     */
+    static TRnRef_T<URnWay> ShallowCloneOrDefault(URnWay* Self);
 };


### PR DESCRIPTION
## 関連リンク
https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/452

https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/454　（こっちは命名規則変更だけな & シリアライズ処理はUEでは行っていないので確認する必要はないです）
のUE移植

## 実装内容
上述のプルリクを参考.
ただし、デバッグエディタ系は移植していません。
https://github.com/Synesthesias/PLATEAU-SDK-for-Unity/pull/452

## 動作確認
上述のプルリクを参考

## 千代田区の穴の開いた道路でうまく道路が分割されないバグ修正
https://synesthesias.slack.com/archives/C0261M64C15/p1741852533910449

一部道路で中央分離帯があるときの道路のマージ処理がうまく動作していなかったので修正


動作確認
千代田区の53394601に対して道路構造作成し、tran_60c426d9-f9aa-4100-9ce0-e0dc8d782ef5__6170のあたりがうまくいっているか確認する
![image](https://github.com/user-attachments/assets/872cda92-f985-4e29-b9f9-c79ffefc419e)


## マージ前確認項目
- [x] Squash and Mergeが選択されていること
- [x] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [x] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること


## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
