### PR TITLE
glTFエクスポート時のテクスチャフォルダをUnityに合わせる

### DIFF
--- a/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshExporter.cpp
@@ -136,6 +136,7 @@ bool FPLATEAUMeshExporter::ExportAsGLTF(const FString& ExportPath, APLATEAUInsta
     const auto ModelDataArray = CreateModelFromActor(ModelActor, Option);
     plateau::meshWriter::GltfWriteOptions GltfOptions;
     GltfOptions.mesh_file_format = Option.bExportAsBinary ? plateau::meshWriter::GltfFileFormat::GLTF : plateau::meshWriter::GltfFileFormat::GLB;
+    GltfOptions.texture_directory_path = "./textures";
     for (int i = 0; i < ModelDataArray.Num(); i++) {
         if (ModelDataArray[i]->getRootNodeCount() != 0) {
 #if WITH_EDITOR


### PR DESCRIPTION
## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
相対パスになってはいるがunityとパスが異なるので合わせます。

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
glTFエクスポートし、フォルダごと移動してもテクスチャ参照があることを確認してください。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
