### PR TITLE
5.5のインポート時のクラッシュ対応

### DIFF
--- a/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
@@ -328,7 +328,6 @@ void FPLATEAUMeshLoader::LoadModel(AActor* ModelActor, USceneComponent* ParentCo
         StaticMeshes.Reset();
     }
 
-    
     FFunctionGraphTask::CreateAndDispatchWhenReady(
         [ParentComponent, PathToTexture=this->PathToTexture, OverwriteTexture=OverwriteTexture()]() {
             // 最大LOD以外の形状を非表示化

--- a/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUMeshLoader.cpp
@@ -328,10 +328,18 @@ void FPLATEAUMeshLoader::LoadModel(AActor* ModelActor, USceneComponent* ParentCo
         StaticMeshes.Reset();
     }
 
-    // 最大LOD以外の形状を非表示化
+    
     FFunctionGraphTask::CreateAndDispatchWhenReady(
-        [ParentComponent]() {
+        [ParentComponent, PathToTexture=this->PathToTexture, OverwriteTexture=OverwriteTexture()]() {
+            // 最大LOD以外の形状を非表示化
             FPLATEAUModelFiltering().FilterLowLods(ParentComponent);
+
+            // Texture保存(5.5のクラッシュ回避のためパッケージ保存はロード後に行う
+            if (OverwriteTexture) {
+                for (const auto TexKV : PathToTexture) {
+                    FPLATEAUTextureLoader::SaveTexture(TexKV.Value, TexKV.Key);
+                }
+            }
         }, TStatId(), nullptr, ENamedThreads::GameThread)->Wait();
 }
 

--- a/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUTextureLoader.cpp
@@ -328,7 +328,7 @@ UTexture2D* FPLATEAUTextureLoader::LoadTransient(const FString& TexturePath) {
 }
 
 // Texture保存(5.5のクラッシュ回避のためパッケージ保存はロード後に行う
-bool FPLATEAUTextureLoader::SaveTexture(UTexture2D* Texture, const FString TexturePath) {
+bool FPLATEAUTextureLoader::SaveTexture(UTexture2D* Texture, const FString& TexturePath) {
     FString PackageName = TEXT("/Game/PLATEAU/Textures/");
     PackageName += FPaths::GetBaseFilename(TexturePath).Replace(TEXT("."), TEXT("_"));
     UPackage* Package = CreatePackage(*PackageName);

--- a/Source/PLATEAURuntime/Public/PLATEAUTextureLoader.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUTextureLoader.h
@@ -9,5 +9,5 @@ class PLATEAURUNTIME_API FPLATEAUTextureLoader {
 public:
     static UTexture2D* Load(const FString& TexturePath, bool OverwriteTextre);
     static UTexture2D* LoadTransient(const FString& TexturePath);
-    static bool SaveTexture(UTexture2D* Texture, const FString TexturePath);
+    static bool SaveTexture(UTexture2D* Texture, const FString& TexturePath);
 };

--- a/Source/PLATEAURuntime/Public/PLATEAUTextureLoader.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUTextureLoader.h
@@ -9,4 +9,5 @@ class PLATEAURUNTIME_API FPLATEAUTextureLoader {
 public:
     static UTexture2D* Load(const FString& TexturePath, bool OverwriteTextre);
     static UTexture2D* LoadTransient(const FString& TexturePath);
+    static bool SaveTexture(UTexture2D* Texture, const FString TexturePath);
 };


### PR DESCRIPTION
## 関連リンク
<!-- libplateauのPR等、関連するPRがあれば書く。 -->

## 実装内容
Textureのパッケージ保存をロード完了後に行うよう変更

## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## 動作確認
メッシュコード1枚分をデフォルトで読み込んだ際にクラッシュしない
インポートしたテクスチャが保存される

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
	- モデルの読み込み時に、テクスチャの上書きと保存が可能になりました。
	- テクスチャパッケージの保存処理を追加し、全体の安定性を向上させました。

- **バグ修正**
	- 特定バージョンで発生していた、テクスチャ処理に起因するクラッシュの可能性を解消しました。

- **リファクタリング**
	- リソース状態の管理とテクスチャ検証処理を改善し、パフォーマンスと信頼性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->