### PR TITLE
MeshCodeからGridCodeに移行

### DIFF
--- a/Config/DefaultPLATEAU-SDK-for-Unreal.ini
+++ b/Config/DefaultPLATEAU-SDK-for-Unreal.ini
@@ -1,0 +1,3 @@
+﻿[CoreRedirects]
++PropertyRedirects=(OldName="/Script/PLATEAURuntime.PLATEAUCityModelLoader.MeshCodes",NewName="/Script/PLATEAURuntime.PLATEAUCityModelLoader.GridCodes")
++PropertyRedirects=(OldName="/Script/PLATEAURuntime.PLATEAUInstancedCityModel.MeshCodes",NewName="/Script/PLATEAURuntime.PLATEAUInstancedCityModel.GridCodes")

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUAsyncLoadedFeatureInfoPanel.h
@@ -7,7 +7,7 @@
 #include "Tasks/Task.h"
 
 struct FPLATEAUFeatureInfoMaterialKey;
-class FPLATEAUMeshCodeGizmo;
+class FPLATEAUGridCodeGizmo;
 
 namespace plateau::dataset {
     class MeshCode;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -73,7 +73,7 @@ void FPLATEAUExtentEditor::SetAreaSourcePath(const FString& InAreaSourcePath) {
 }
 
 bool FPLATEAUExtentEditor::IsSelectedArea() const {
-    return Algo::AnyOf(GetAreaMeshCodeMap(), [](const TTuple<FString, FPLATEAUGridCodeGizmo>& MeshCodeGizmoTuple) {
+    return Algo::AnyOf(GetGridCodeMap(), [](const TTuple<FString, FPLATEAUGridCodeGizmo>& MeshCodeGizmoTuple) {
         return MeshCodeGizmoTuple.Value.bSelectedArea();
     });
 }
@@ -98,11 +98,11 @@ TArray<FString> FPLATEAUExtentEditor::GetSelectedCodes(const bool InbImportFromS
     return Codes;
 }
 
-TMap<FString, FPLATEAUGridCodeGizmo> FPLATEAUExtentEditor::GetAreaMeshCodeMap() const {
+TMap<FString, FPLATEAUGridCodeGizmo> FPLATEAUExtentEditor::GetGridCodeMap() const {
     return IsImportFromServer() ? ServerAreaMeshCodeMap : LocalAreaMeshCodeMap;
 }
 
-void FPLATEAUExtentEditor::SetAreaMeshCodeMap(const FString& MeshCode, const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
+void FPLATEAUExtentEditor::SetGridCodeMap(const FString& MeshCode, const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
     if (IsImportFromServer()) {
         ServerAreaMeshCodeMap.Emplace(MeshCode, MeshCodeGizmo);
     } else {
@@ -110,7 +110,7 @@ void FPLATEAUExtentEditor::SetAreaMeshCodeMap(const FString& MeshCode, const FPL
     }
 }
 
-void FPLATEAUExtentEditor::ResetAreaMeshCodeMap() {
+void FPLATEAUExtentEditor::ResetGridCodeMap() {
     if (IsImportFromServer()) {
         ServerAreaMeshCodeMap.Reset();
     } else {

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -174,7 +174,7 @@ plateau::geometry::GeoCoordinate FPLATEAUExtentEditor::GetSelectedCenterLatLon(c
         plateau::geometry::GeoCoordinate(-180.0, -180.0, 0.0));
 
     for (const auto& Code : SelectedCodes) {
-        const auto NativePartialExtent = plateau::dataset::MeshCode(TCHAR_TO_UTF8(*Code)).getExtent();
+        const auto NativePartialExtent = plateau::dataset::GridCode::create(TCHAR_TO_UTF8(*Code))->getExtent();
         NativeExtent.min.latitude = std::min(NativeExtent.min.latitude, NativePartialExtent.min.latitude);
         NativeExtent.min.longitude = std::min(NativeExtent.min.longitude, NativePartialExtent.min.longitude);
         NativeExtent.max.latitude = std::max(NativeExtent.max.latitude, NativePartialExtent.max.latitude);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditor.cpp
@@ -5,7 +5,7 @@
 #include "Algo/AnyOf.h"
 
 #include "PLATEAUEditor.h"
-#include "PLATEAUMeshCodeGizmo.h"
+#include "PLATEAUGridCodeGizmo.h"
 #include "PLATEAUWindow.h"
 #include "Widgets/Docking/SDockTab.h"
 #include "Widgets/PLATEAUSDKEditorUtilityWidget.h"
@@ -73,7 +73,7 @@ void FPLATEAUExtentEditor::SetAreaSourcePath(const FString& InAreaSourcePath) {
 }
 
 bool FPLATEAUExtentEditor::IsSelectedArea() const {
-    return Algo::AnyOf(GetAreaMeshCodeMap(), [](const TTuple<FString, FPLATEAUMeshCodeGizmo>& MeshCodeGizmoTuple) {
+    return Algo::AnyOf(GetAreaMeshCodeMap(), [](const TTuple<FString, FPLATEAUGridCodeGizmo>& MeshCodeGizmoTuple) {
         return MeshCodeGizmoTuple.Value.bSelectedArea();
     });
 }
@@ -84,13 +84,13 @@ TArray<FString> FPLATEAUExtentEditor::GetSelectedCodes(const bool InbImportFromS
     if (InbImportFromServer) {
         for (auto [_, Value] : ServerAreaMeshCodeMap) {
             if (Value.bSelectedArea()) {
-                Codes.Append(Value.GetSelectedMeshIds());
+                Codes.Append(Value.GetSelectedGridCodeIDs());
             }
         }
     } else {
         for (auto [_, Value] : LocalAreaMeshCodeMap) {
             if (Value.bSelectedArea()) {
-                Codes.Append(Value.GetSelectedMeshIds());
+                Codes.Append(Value.GetSelectedGridCodeIDs());
             }
         }
     }
@@ -98,11 +98,11 @@ TArray<FString> FPLATEAUExtentEditor::GetSelectedCodes(const bool InbImportFromS
     return Codes;
 }
 
-TMap<FString, FPLATEAUMeshCodeGizmo> FPLATEAUExtentEditor::GetAreaMeshCodeMap() const {
+TMap<FString, FPLATEAUGridCodeGizmo> FPLATEAUExtentEditor::GetAreaMeshCodeMap() const {
     return IsImportFromServer() ? ServerAreaMeshCodeMap : LocalAreaMeshCodeMap;
 }
 
-void FPLATEAUExtentEditor::SetAreaMeshCodeMap(const FString& MeshCode, const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
+void FPLATEAUExtentEditor::SetAreaMeshCodeMap(const FString& MeshCode, const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
     if (IsImportFromServer()) {
         ServerAreaMeshCodeMap.Emplace(MeshCode, MeshCodeGizmo);
     } else {

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.cpp
@@ -50,7 +50,7 @@ FPLATEAUExtentEditorViewportClient::~FPLATEAUExtentEditorViewportClient() {
 
 void FPLATEAUExtentEditorViewportClient::Initialize(const std::shared_ptr<plateau::dataset::IDatasetAccessor>& InDatasetAccessor) {
     DatasetAccessor = InDatasetAccessor;
-    const auto& MeshCodes = DatasetAccessor->getMeshCodes();
+    const auto& GridCodes = DatasetAccessor->getGridCodes();
     const auto ExtentEditor = ExtentEditorPtr.Pin();
 
     InitCamera();
@@ -65,25 +65,32 @@ void FPLATEAUExtentEditorViewportClient::Initialize(const std::shared_ptr<platea
     // メッシュコードギズモ生成と選択状態復帰
     auto GeoReference = ExtentEditor->GetGeoReference();
     MeshCodeGizmos.Reset();
-    for (const auto& MeshCode : MeshCodes) {
+    for (const auto& GridCode : GridCodes) {
         // 2次メッシュ以下の次数は省く
-        if (MeshCode.getLevel() <= 2)
+        if (!GridCode->isNormalGmlLevel() && !GridCode->isSmallerThanNormalGml())
             continue;
 
         // Level4以上のMeshCodeであって、別のLevel3の範囲に含まれているものは重複のため除外します。
-        if (MeshCode.getLevel() >= 4) {
-            FString code = UTF8_TO_TCHAR(MeshCode.get().c_str());
-            FString ThirdMeshCodeString = code.Mid(0, 8);
-            const auto ThirdMeshCode = plateau::dataset::MeshCode(TCHAR_TO_UTF8(*ThirdMeshCodeString));
-            if (MeshCodes.find(ThirdMeshCode) != MeshCodes.end()) {             
-                continue;
+        if (GridCode->isSmallerThanNormalGml()) {
+            FString code = UTF8_TO_TCHAR(GridCode->get().c_str());
+            auto UpperGridCode = GridCode->upper();
+            while(!UpperGridCode->isNormalGmlLevel())
+            {
+                UpperGridCode = UpperGridCode->upper();
+            }
+            for(const auto& OtherGridCode : GridCodes)
+            {
+                if(OtherGridCode->get() == UpperGridCode->get())
+                {
+                    continue;
+                }
             }
         }
 
         MeshCodeGizmos.AddDefaulted();
-        MeshCodeGizmos.Last().Init(MeshCode, GeoReference.GetData());
-        if (ExtentEditor->GetAreaMeshCodeMap().Contains(UTF8_TO_TCHAR(MeshCode.get().c_str()))) {
-            MeshCodeGizmos.Last().SetbSelectedArray(ExtentEditor->GetAreaMeshCodeMap()[UTF8_TO_TCHAR(MeshCode.get().c_str())].GetbSelectedArray());
+        MeshCodeGizmos.Last().Init(GridCode, GeoReference.GetData());
+        if (ExtentEditor->GetAreaMeshCodeMap().Contains(UTF8_TO_TCHAR(GridCode->get().c_str()))) {
+            MeshCodeGizmos.Last().SetbSelectedArray(ExtentEditor->GetAreaMeshCodeMap()[UTF8_TO_TCHAR(GridCode->get().c_str())].GetbSelectedArray());
         }
     }
 }
@@ -227,7 +234,7 @@ FPLATEAUMeshCodeGizmo FPLATEAUExtentEditorViewportClient::GetNearestMeshCodeGizm
         if (FeatureInfoDisplay->MeshCodeGizmoContains(MeshCodeGizmo))
             continue;
         
-        auto DistFromCenter = MeshCodeGizmo.GetMeshCode().getExtent().centerPoint() - Extent.GetNativeData().centerPoint();
+        auto DistFromCenter = MeshCodeGizmo.GetGridCode()->getExtent().centerPoint() - Extent.GetNativeData().centerPoint();
         // 緯度・経度の値でそのまま距離を取ると、探索範囲が縦長になり、画面の上下にはみ出した箇所が探索されがちになります。
         // これを補正するため、縦よりも横を優先します。
         // 探索範囲が横長になり、横に長いディスプレイに映る範囲が優先的に探索されるようにします。
@@ -364,15 +371,25 @@ bool FPLATEAUExtentEditorViewportClient::TryGetWorldPositionOfCursor(FVector& Po
     return FMath::SegmentPlaneIntersection(StartPoint, EndPoint, Plane, Position);
 }
 
-bool FPLATEAUExtentEditorViewportClient::SetViewLocationByMeshCode(FString meshCode) {
-    const auto MeshCode = plateau::dataset::MeshCode(TCHAR_TO_UTF8(*meshCode));
-    if (!MeshCode.isValid())
+bool FPLATEAUExtentEditorViewportClient::SetViewLocationByGridCode(FString StrGridCode) {
+    const auto GridCode = plateau::dataset::GridCode::create(TCHAR_TO_UTF8(*StrGridCode));
+    if (!GridCode->isValid())
         return false;
-    std::set<plateau::dataset::MeshCode> MeshCodes = DatasetAccessor->getMeshCodes();
-    if( !std::any_of(MeshCodes.begin(), MeshCodes.end(), [&](plateau::dataset::MeshCode c) { return MeshCode.isWithin(c); }))
+    std::set<std::shared_ptr<plateau::dataset::GridCode>, plateau::dataset::GridCodeComparator> DataGridCodes = DatasetAccessor->getGridCodes();
+    if( !std::any_of(DataGridCodes.begin(), DataGridCodes.end(), [&](std::shared_ptr<plateau::dataset::GridCode> dataGC)
+    {
+        // 範囲が含まれるかどうかチェックします。
+        if(GridCode->get() == dataGC->get()) return true;
+        auto Upper = GridCode->upper();
+        if(Upper->isValid())
+        {
+            return Upper->get() == dataGC->get(); 
+        }
+        return false;
+    }))
         return false;       
     const auto ExtentEditor = ExtentEditorPtr.Pin();     
-    const auto Box = ExtentEditor->GetBoxByExtent(MeshCode.getExtent());
+    const auto Box = ExtentEditor->GetBoxByExtent(GridCode->getExtent());
     if (!Box.IsValid) return false;
     FocusViewportOnBox(Box, true);
     return true;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -65,11 +65,11 @@ private:
     FVector CachedWorldMousePos; 
     FVector TrackingStartedPosition;
     FVector TrackingStartedCameraPosition;
-    TArray<class FPLATEAUGridCodeGizmo> MeshCodeGizmos;
+    TArray<class FPLATEAUGridCodeGizmo> GridCodeGizmos;
     
     bool GizmoContains(const FPLATEAUGridCodeGizmo& Gizmo) const;
     FVector GetWorldPosition(uint32 X, uint32 Y);
     bool TryGetWorldPositionOfCursor(FVector& Position);
     void InitCamera();
-    FPLATEAUGridCodeGizmo GetNearestMeshCodeGizmo();
+    FPLATEAUGridCodeGizmo GetNearestGridCodeGizmo();
 };

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -65,11 +65,11 @@ private:
     FVector CachedWorldMousePos; 
     FVector TrackingStartedPosition;
     FVector TrackingStartedCameraPosition;
-    TArray<class FPLATEAUMeshCodeGizmo> MeshCodeGizmos;
+    TArray<class FPLATEAUGridCodeGizmo> MeshCodeGizmos;
     
-    bool GizmoContains(const FPLATEAUMeshCodeGizmo& Gizmo) const;
+    bool GizmoContains(const FPLATEAUGridCodeGizmo& Gizmo) const;
     FVector GetWorldPosition(uint32 X, uint32 Y);
     bool TryGetWorldPositionOfCursor(FVector& Position);
     void InitCamera();
-    FPLATEAUMeshCodeGizmo GetNearestMeshCodeGizmo();
+    FPLATEAUGridCodeGizmo GetNearestMeshCodeGizmo();
 };

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUExtentEditorVPClient.h
@@ -44,7 +44,7 @@ public:
     virtual bool ShouldScaleCameraSpeedByDistance() const override;
 
     void SwitchFeatureInfoDisplay(const int Lod, const bool bCheck) const;
-    bool SetViewLocationByMeshCode(FString meshCode);
+    bool SetViewLocationByGridCode(FString StrGridCode);
 
 private:
     // このインスタンスを保持しているExtentEditorへのポインタ

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -99,7 +99,7 @@ FPLATEAUFeatureInfoDisplay::~FPLATEAUFeatureInfoDisplay() {}
 
 bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUGridCodeGizmo& MeshCodeGizmo, const IDatasetAccessor& InDatasetAccessor) {
     // 生成済みの場合はスキップ
-    if (MeshCodeGizmoContains(MeshCodeGizmo))
+    if (GridCodeGizmoContains(MeshCodeGizmo))
         return false;
 
     const auto AsyncLoadedTile = MakeShared<FPLATEAUAsyncLoadedFeatureInfoPanel>(SharedThis(this), ViewportClient);
@@ -131,7 +131,7 @@ int FPLATEAUFeatureInfoDisplay::CountLoadingPanels() {
 }
 
 bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
-    if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+    if (GridCodeGizmoContains(MeshCodeGizmo)) {
         return AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->AddIconComponent();
     }
 
@@ -156,7 +156,7 @@ EPLATEAUFeatureInfoVisibility FPLATEAUFeatureInfoDisplay::GetVisibility() const 
 
 void FPLATEAUFeatureInfoDisplay::SetVisibility(const FPLATEAUGridCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value) {
     Visibility = Value;
-    if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+    if (GridCodeGizmoContains(MeshCodeGizmo)) {
         AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->RecalculateIconTransform(ShowLods);
         AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility);
     }
@@ -231,7 +231,7 @@ void FPLATEAUFeatureInfoDisplay::SwitchFeatureInfoDisplay(const TArray<FPLATEAUG
     }
 
     for (const auto& MeshCodeGizmo : MeshCodeGizmos) {
-        if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+        if (GridCodeGizmoContains(MeshCodeGizmo)) {
             AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->RecalculateIconTransform(ShowLods);
             AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility, true);
         }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -72,11 +72,11 @@ namespace {
 
     std::shared_ptr<std::vector<GmlFile>> FindGmlFiles(
         const IDatasetAccessor& InDatasetAccessor,
-        const MeshCode& InMeshCode,
+        const std::shared_ptr<GridCode>& InGridCode,
         const PredefinedCityModelPackage InPackage) {
 
         return InDatasetAccessor
-            .filterByMeshCodes({ InMeshCode })
+            .filterByGridCodes({ InGridCode })
             ->getGmlFiles(InPackage);
     }
 }
@@ -108,10 +108,10 @@ bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUMeshCodeGizmo& M
     FPLATEAUFeatureInfoPanelInput Input;
     const auto Packages = GetDisplayedPackages();
     for (const auto& Package : GetDisplayedPackages()) {
-        Input.Add(Package, FindGmlFiles(InDatasetAccessor, MeshCodeGizmo.GetMeshCode(), Package));
+        Input.Add(Package, FindGmlFiles(InDatasetAccessor, MeshCodeGizmo.GetGridCode(), Package));
     }
 
-    const auto TileExtent = MeshCodeGizmo.GetMeshCode().getExtent();
+    const auto TileExtent = MeshCodeGizmo.GetGridCode()->getExtent();
     const auto RawTileMax = GeoReference.GetData().project(TileExtent.max);
     const auto RawTileMin = GeoReference.GetData().project(TileExtent.min);
     const FBox Box{FVector(RawTileMin.x, RawTileMin.y, RawTileMin.z), FVector(RawTileMax.x, RawTileMax.y, RawTileMax.z)};

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.cpp
@@ -97,13 +97,13 @@ FPLATEAUFeatureInfoDisplay::FPLATEAUFeatureInfoDisplay(
 
 FPLATEAUFeatureInfoDisplay::~FPLATEAUFeatureInfoDisplay() {}
 
-bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const IDatasetAccessor& InDatasetAccessor) {
+bool FPLATEAUFeatureInfoDisplay::CreatePanelAsync(const FPLATEAUGridCodeGizmo& MeshCodeGizmo, const IDatasetAccessor& InDatasetAccessor) {
     // 生成済みの場合はスキップ
     if (MeshCodeGizmoContains(MeshCodeGizmo))
         return false;
 
     const auto AsyncLoadedTile = MakeShared<FPLATEAUAsyncLoadedFeatureInfoPanel>(SharedThis(this), ViewportClient);
-    AsyncLoadedPanels.Add(MeshCodeGizmo.GetRegionMeshID(), AsyncLoadedTile);
+    AsyncLoadedPanels.Add(MeshCodeGizmo.GetRegionGridCodeID(), AsyncLoadedTile);
 
     FPLATEAUFeatureInfoPanelInput Input;
     const auto Packages = GetDisplayedPackages();
@@ -130,9 +130,9 @@ int FPLATEAUFeatureInfoDisplay::CountLoadingPanels() {
     return Count;
 }
 
-bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
+bool FPLATEAUFeatureInfoDisplay::AddComponent(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
     if (MeshCodeGizmoContains(MeshCodeGizmo)) {
-        return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->AddIconComponent();
+        return AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->AddIconComponent();
     }
 
     return false;
@@ -154,11 +154,11 @@ EPLATEAUFeatureInfoVisibility FPLATEAUFeatureInfoDisplay::GetVisibility() const 
     return Visibility;
 }
 
-void FPLATEAUFeatureInfoDisplay::SetVisibility(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value) {
+void FPLATEAUFeatureInfoDisplay::SetVisibility(const FPLATEAUGridCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value) {
     Visibility = Value;
     if (MeshCodeGizmoContains(MeshCodeGizmo)) {
-        AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->RecalculateIconTransform(ShowLods);
-        AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility);
+        AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->RecalculateIconTransform(ShowLods);
+        AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility);
     }
 }
 
@@ -223,7 +223,7 @@ TArray<FString> FPLATEAUFeatureInfoDisplay::GetIconFileNameList() {
     return TArray<FString> {BuildingIcon, TrafficIcon, PropsIcon, BridgeIcon, PlantsIcon, UndergroundIcon, TerrainIcon, OtherIcon};
 }
 
-void FPLATEAUFeatureInfoDisplay::SwitchFeatureInfoDisplay(const TArray<FPLATEAUMeshCodeGizmo>& MeshCodeGizmos, const int Lod, const bool bCheck) {
+void FPLATEAUFeatureInfoDisplay::SwitchFeatureInfoDisplay(const TArray<FPLATEAUGridCodeGizmo>& MeshCodeGizmos, const int Lod, const bool bCheck) {
     if (bCheck) {
         ShowLods.AddUnique(Lod);
     } else {
@@ -232,8 +232,8 @@ void FPLATEAUFeatureInfoDisplay::SwitchFeatureInfoDisplay(const TArray<FPLATEAUM
 
     for (const auto& MeshCodeGizmo : MeshCodeGizmos) {
         if (MeshCodeGizmoContains(MeshCodeGizmo)) {
-            AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->RecalculateIconTransform(ShowLods);
-            AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility, true);
+            AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->RecalculateIconTransform(ShowLods);
+            AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->SetFeatureInfoVisibility(ShowLods, Visibility, true);
         }
     }
 }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
@@ -5,7 +5,7 @@
 #include "CoreMinimal.h"
 #include "PLATEAUAsyncLoadedFeatureInfoPanel.h"
 #include "PLATEAUGeometry.h"
-#include "PLATEAUMeshCodeGizmo.h"
+#include "PLATEAUGridCodeGizmo.h"
 
 namespace plateau::Feature {
     constexpr int MinLod = 0;
@@ -61,8 +61,8 @@ public:
     FPLATEAUFeatureInfoDisplay(const FPLATEAUGeoReference& InGeoReference, const TSharedPtr<class FPLATEAUExtentEditorViewportClient> InViewportClient);
     ~FPLATEAUFeatureInfoDisplay();
 
-    bool CreatePanelAsync(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const plateau::dataset::IDatasetAccessor& InDatasetAccessor);
-    bool AddComponent(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo);
+    bool CreatePanelAsync(const FPLATEAUGridCodeGizmo& MeshCodeGizmo, const plateau::dataset::IDatasetAccessor& InDatasetAccessor);
+    bool AddComponent(const FPLATEAUGridCodeGizmo& MeshCodeGizmo);
 
     int CountLoadingPanels();
 
@@ -77,7 +77,7 @@ public:
     /**
      * @brief 地物情報パネルの可視性を設定します。
      */
-    void SetVisibility(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value);
+    void SetVisibility(const FPLATEAUGridCodeGizmo& MeshCodeGizmo, const EPLATEAUFeatureInfoVisibility Value);
 
     /**
      * @brief 範囲選択画面に表示する各パッケージリストを取得
@@ -94,18 +94,18 @@ public:
      */  
     static TArray<FString> GetIconFileNameList();
 
-    bool MeshCodeGizmoContains(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) const {
-        return AsyncLoadedPanels.Contains(MeshCodeGizmo.GetRegionMeshID());
+    bool MeshCodeGizmoContains(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) const {
+        return AsyncLoadedPanels.Contains(MeshCodeGizmo.GetRegionGridCodeID());
     }
     
-    int GetItemCount(const FPLATEAUMeshCodeGizmo& MeshCodeGizmo) {
+    int GetItemCount(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
         if (MeshCodeGizmoContains(MeshCodeGizmo)) {
-            return AsyncLoadedPanels[MeshCodeGizmo.GetRegionMeshID()].Get()->GetIconCount();
+            return AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->GetIconCount();
         }
         return 0;
     }
 
-    void SwitchFeatureInfoDisplay(const TArray<FPLATEAUMeshCodeGizmo>& MeshCodeGizmos, const int Lod, const bool bCheck);
+    void SwitchFeatureInfoDisplay(const TArray<FPLATEAUGridCodeGizmo>& MeshCodeGizmos, const int Lod, const bool bCheck);
 private:
     FPLATEAUGeoReference GeoReference;
     TWeakPtr<class FPLATEAUExtentEditorViewportClient> ViewportClient;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUFeatureInfoDisplay.h
@@ -94,12 +94,12 @@ public:
      */  
     static TArray<FString> GetIconFileNameList();
 
-    bool MeshCodeGizmoContains(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) const {
+    bool GridCodeGizmoContains(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) const {
         return AsyncLoadedPanels.Contains(MeshCodeGizmo.GetRegionGridCodeID());
     }
     
     int GetItemCount(const FPLATEAUGridCodeGizmo& MeshCodeGizmo) {
-        if (MeshCodeGizmoContains(MeshCodeGizmo)) {
+        if (GridCodeGizmoContains(MeshCodeGizmo)) {
             return AsyncLoadedPanels[MeshCodeGizmo.GetRegionGridCodeID()].Get()->GetIconCount();
         }
         return 0;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.cpp
@@ -64,6 +64,10 @@ FPLATEAUGridCodeGizmo::FPLATEAUGridCodeGizmo() : GridCode(), Width(0), Height(0)
 }
 
 bool FPLATEAUGridCodeGizmo::IsSelectable() const {
+    if (!ensure(GridCode))
+    {
+        return false;
+    }
     return GridCode->isNormalGmlLevel() || GridCode->isSmallerThanNormalGml();
 }
 
@@ -201,12 +205,12 @@ void FPLATEAUGridCodeGizmo::Init(const std::shared_ptr<plateau::dataset::GridCod
     const auto RawMax = InGeoReference.project(Extent.max);
     GridCode = InGridCode;
     GridCodeString = UTF8_TO_TCHAR(InGridCode->get().c_str());
-    Width = MaxX - MinX;
-    Height = MaxY - MinY;
     MinX = FGenericPlatformMath::Min(RawMin.x, RawMax.x);
     MinY = FGenericPlatformMath::Min(RawMin.y, RawMax.y);
     MaxX = FGenericPlatformMath::Max(RawMin.x, RawMax.x);
     MaxY = FGenericPlatformMath::Max(RawMin.y, RawMax.y);
+    Width = MaxX - MinX;
+    Height = MaxY - MinY;
     LineThickness = 2.0f;
 
     const int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.cpp
@@ -1,7 +1,7 @@
 // Copyright © 2023 Ministry of Land, Infrastructure and Transport
 
 
-#include "PLATEAUMeshCodeGizmo.h"
+#include "PLATEAUGridCodeGizmo.h"
 
 #include "SceneManagement.h"
 
@@ -15,11 +15,11 @@
 
 namespace {
 
-    int GetNumAreaColumnByMeshCode(const std::shared_ptr<plateau::dataset::GridCode>& GridCode) {
+    int GetNumAreaColumnByGridCode(const std::shared_ptr<plateau::dataset::GridCode>& GridCode) {
         return GridCode->isSmallerThanNormalGml() ? 2 : 4;
     }
 
-    int GetNumAreaRowByMeshCode(const std::shared_ptr<plateau::dataset::GridCode>& GridCode) {
+    int GetNumAreaRowByGridCode(const std::shared_ptr<plateau::dataset::GridCode>& GridCode) {
         return GridCode->isSmallerThanNormalGml() ? 2 : 4;
     }
 
@@ -54,7 +54,7 @@ namespace {
     }
 }
 
-FPLATEAUMeshCodeGizmo::FPLATEAUMeshCodeGizmo() : GridCode(), Width(0), Height(0), MinX(-500), MinY(-500), MaxX(500), MaxY(500), LineThickness(1.0f) {
+FPLATEAUGridCodeGizmo::FPLATEAUGridCodeGizmo() : GridCode(), Width(0), Height(0), MinX(-500), MinY(-500), MaxX(500), MaxY(500), LineThickness(1.0f) {
     AreaSelectedMaterial = DuplicateObject(GEngine->ConstraintLimitMaterialPrismatic, nullptr);
     AreaSelectedMaterial.Get()->SetScalarParameterValue(FName("Desaturation"), 1.0f);
     AreaSelectedMaterial.Get()->SetVectorParameterValue(FName("Color"), SelectedColor);
@@ -63,21 +63,21 @@ FPLATEAUMeshCodeGizmo::FPLATEAUMeshCodeGizmo() : GridCode(), Width(0), Height(0)
     AreaUnSelectedMaterial.Get()->SetVectorParameterValue(FName("Color"), UnselectedColor);
 }
 
-bool FPLATEAUMeshCodeGizmo::IsSelectable() const {
+bool FPLATEAUGridCodeGizmo::IsSelectable() const {
     return GridCode->isNormalGmlLevel() || GridCode->isSmallerThanNormalGml();
 }
 
-void FPLATEAUMeshCodeGizmo::ResetSelectedArea() {
+void FPLATEAUGridCodeGizmo::ResetSelectedArea() {
     for (int i = 0; i < bSelectedArray.Num(); i++) {
         bSelectedArray[i] = false;
     }
 }
 
-void FPLATEAUMeshCodeGizmo::DrawExtent(const FSceneView* View, FPrimitiveDrawInterface* PDI) const {
+void FPLATEAUGridCodeGizmo::DrawExtent(const FSceneView* View, FPrimitiveDrawInterface* PDI) const {
     const FBox Box(FVector(MinX, MinY, 0), FVector(MaxX, MaxY, 0));
     const auto Color = FColor(10, 10, 130);
-    const int NumAreaColumn = GetNumAreaColumnByMeshCode(GridCode);
-    const int NumAreaRow = GetNumAreaRowByMeshCode(GridCode);
+    const int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);
+    const int NumAreaRow = GetNumAreaRowByGridCode(GridCode);
 
     // エリア枠線
     DrawWireBox(PDI, Box, Color, SDPG_World, LineThickness, 0, true);
@@ -130,7 +130,7 @@ void FPLATEAUMeshCodeGizmo::DrawExtent(const FSceneView* View, FPrimitiveDrawInt
     }
 }
 
-void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& RegionMeshID,
+void FPLATEAUGridCodeGizmo::DrawRegionGridCodeID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& GridCodeID,
                                              double CameraDistance, int IconCount) const {
     if (GridCode->isSmallerThanNormalGml()) return;
     
@@ -149,58 +149,58 @@ void FPLATEAUMeshCodeGizmo::DrawRegionMeshID(const FViewport& InViewport, const 
 
     const UFont* ViewFont = GEngine->GetLargeFont();
 
-    const auto HalfWidth = ViewFont->GetStringSize(*RegionMeshID) / 2;
-    const auto HalfHeight = ViewFont->GetStringHeightSize(*RegionMeshID) / 2;
+    const auto HalfWidth = ViewFont->GetStringSize(*GridCodeID) / 2;
+    const auto HalfHeight = ViewFont->GetStringHeightSize(*GridCodeID) / 2;
 
     const auto Color = FColor::Blue;
 
     if (ViewPlane.W > 0.f) {
-        if (CameraDistance < plateau::geometry::ShowRegionMeshIdCameraDistance) {
-            Canvas.DrawShadowedText(XPos - HalfWidth, YPos - HalfHeight, FText::FromString(RegionMeshID), ViewFont, Color);
+        if (CameraDistance < plateau::geometry::ShowGridCodeIdCameraDistance) {
+            Canvas.DrawShadowedText(XPos - HalfWidth, YPos - HalfHeight, FText::FromString(GridCodeID), ViewFont, Color);
         }
     }
 }
 
-FVector2D FPLATEAUMeshCodeGizmo::GetMin() const {
+FVector2D FPLATEAUGridCodeGizmo::GetMin() const {
     return FVector2D(MinX, MinY);
 }
 
-FVector2D FPLATEAUMeshCodeGizmo::GetMax() const {
+FVector2D FPLATEAUGridCodeGizmo::GetMax() const {
     return FVector2D(MaxX, MaxY);
 }
 
-FVector2D FPLATEAUMeshCodeGizmo::GetSize() const {
+FVector2D FPLATEAUGridCodeGizmo::GetSize() const {
     return FVector2D(Width, Height);
 }
 
-std::shared_ptr<plateau::dataset::GridCode> FPLATEAUMeshCodeGizmo::GetGridCode() const {
+std::shared_ptr<plateau::dataset::GridCode> FPLATEAUGridCodeGizmo::GetGridCode() const {
     return GridCode;
 }
 
-FString FPLATEAUMeshCodeGizmo::GetRegionMeshID() const {
-    return MeshCodeString;
+FString FPLATEAUGridCodeGizmo::GetRegionGridCodeID() const {
+    return GridCodeString;
 }
 
-TArray<bool> FPLATEAUMeshCodeGizmo::GetbSelectedArray() const {
+TArray<bool> FPLATEAUGridCodeGizmo::GetbSelectedArray() const {
     return bSelectedArray;
 }
 
-bool FPLATEAUMeshCodeGizmo::bSelectedArea() const {
+bool FPLATEAUGridCodeGizmo::bSelectedArea() const {
     return Algo::AnyOf(bSelectedArray, [](const bool bSelected) {
         return bSelected;
     });
 }
 
-void FPLATEAUMeshCodeGizmo::SetbSelectedArray(const TArray<bool>& InbSelectedArray) {
+void FPLATEAUGridCodeGizmo::SetbSelectedArray(const TArray<bool>& InbSelectedArray) {
     bSelectedArray = InbSelectedArray;
 }
 
-void FPLATEAUMeshCodeGizmo::Init(const std::shared_ptr<plateau::dataset::GridCode>& InGridCode, const plateau::geometry::GeoReference& InGeoReference) {
+void FPLATEAUGridCodeGizmo::Init(const std::shared_ptr<plateau::dataset::GridCode>& InGridCode, const plateau::geometry::GeoReference& InGeoReference) {
     const auto Extent = InGridCode->getExtent();
     const auto RawMin = InGeoReference.project(Extent.min);
     const auto RawMax = InGeoReference.project(Extent.max);
     GridCode = InGridCode;
-    MeshCodeString = UTF8_TO_TCHAR(InGridCode->get().c_str());
+    GridCodeString = UTF8_TO_TCHAR(InGridCode->get().c_str());
     Width = MaxX - MinX;
     Height = MaxY - MinY;
     MinX = FGenericPlatformMath::Min(RawMin.x, RawMax.x);
@@ -209,15 +209,15 @@ void FPLATEAUMeshCodeGizmo::Init(const std::shared_ptr<plateau::dataset::GridCod
     MaxY = FGenericPlatformMath::Max(RawMin.y, RawMax.y);
     LineThickness = 2.0f;
 
-    const int NumAreaColumn = GetNumAreaColumnByMeshCode(GridCode);
-    const int NumAreaRow = GetNumAreaRowByMeshCode(GridCode);
+    const int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);
+    const int NumAreaRow = GetNumAreaRowByGridCode(GridCode);
     bSelectedArray.Reset();
     for (int i = 0; i < NumAreaRow * NumAreaColumn; i++) {
         bSelectedArray.Emplace(false);
     }
 }
 
-void FPLATEAUMeshCodeGizmo::ToggleSelectArea(const double X, const double Y) {
+void FPLATEAUGridCodeGizmo::ToggleSelectArea(const double X, const double Y) {
 
     if (!IsSelectable()) 
         return;
@@ -226,20 +226,20 @@ void FPLATEAUMeshCodeGizmo::ToggleSelectArea(const double X, const double Y) {
         return;
     }
 
-    int NumAreaColumn = GetNumAreaColumnByMeshCode(GridCode);
-    int NumAreaRow = GetNumAreaRowByMeshCode(GridCode);
+    int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);
+    int NumAreaRow = GetNumAreaRowByGridCode(GridCode);
     const auto RowIndex = GetRowIndex(MinX, MaxX, NumAreaRow, X);
     const auto ColumnIndex = GetColumnIndex(MinY, MaxY, NumAreaColumn, Y);
     bSelectedArray[RowIndex + ColumnIndex * NumAreaColumn] = !bSelectedArray[RowIndex + ColumnIndex * NumAreaColumn];
 }
 
-void FPLATEAUMeshCodeGizmo::SetSelectArea(const FVector2d InMin, const FVector2d InMax, const bool bSelect) {
+void FPLATEAUGridCodeGizmo::SetSelectArea(const FVector2d InMin, const FVector2d InMax, const bool bSelect) {
 
     if (!IsSelectable()) 
         return;
 
-    const int NumAreaColumn = GetNumAreaColumnByMeshCode(GridCode);
-    const int NumAreaRow = GetNumAreaRowByMeshCode(GridCode);   
+    const int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);
+    const int NumAreaRow = GetNumAreaRowByGridCode(GridCode);   
     const auto CellWidth = (MaxX - MinX) / NumAreaRow;
     const auto CellHeight = (MaxY - MinY) / NumAreaColumn;
     for (int Col = 0; Col < NumAreaColumn; Col++) {
@@ -256,7 +256,7 @@ void FPLATEAUMeshCodeGizmo::SetSelectArea(const FVector2d InMin, const FVector2d
     }
 }
 
-void FPLATEAUMeshCodeGizmo::SetSelectArea(const double X, const double Y, const bool bSelect) {
+void FPLATEAUGridCodeGizmo::SetSelectArea(const double X, const double Y, const bool bSelect) {
 
     if (!IsSelectable()) 
         return;
@@ -265,23 +265,23 @@ void FPLATEAUMeshCodeGizmo::SetSelectArea(const double X, const double Y, const 
         return;
     }
 
-    const int NumAreaColumn = GetNumAreaColumnByMeshCode(GridCode);
-    const int NumAreaRow = GetNumAreaRowByMeshCode(GridCode);
+    const int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);
+    const int NumAreaRow = GetNumAreaRowByGridCode(GridCode);
     const auto RowIndex = GetRowIndex(MinX, MaxX, NumAreaRow, X);
     const auto ColumnIndex = GetColumnIndex(MinY, MaxY, NumAreaColumn, Y);
     bSelectedArray[RowIndex + ColumnIndex * NumAreaColumn] = bSelect;
 }
 
-TArray<FString> FPLATEAUMeshCodeGizmo::GetSelectedMeshIds() {
+TArray<FString> FPLATEAUGridCodeGizmo::GetSelectedGridCodeIDs() {
 
-    const int NumAreaColumn = GetNumAreaColumnByMeshCode(GridCode);
-    const int NumAreaRow = GetNumAreaRowByMeshCode(GridCode);
-    TArray<FString> MeshIdArray;
+    const int NumAreaColumn = GetNumAreaColumnByGridCode(GridCode);
+    const int NumAreaRow = GetNumAreaRowByGridCode(GridCode);
+    TArray<FString> GridCodeIDArray;
 
     if (bSelectedArray.Num() < SuffixMeshIds.Num()) { //Level4
         for (int i = 0; i < bSelectedArray.Num(); i++) {
             if (bSelectedArray[i]){
-                MeshIdArray.Emplace(FString::Format(TEXT("{0}{1}"), { MeshCodeString, i + 1 }));
+                GridCodeIDArray.Emplace(FString::Format(TEXT("{0}{1}"), { GridCodeString, i + 1 }));
             }
         }
     } 
@@ -289,14 +289,14 @@ TArray<FString> FPLATEAUMeshCodeGizmo::GetSelectedMeshIds() {
         for (int Col = 0; Col < NumAreaColumn; Col++) {
             for (int Row = 0; Row < NumAreaRow; Row++) {
                 if (bSelectedArray[Row + Col * NumAreaColumn]) {
-                    MeshIdArray.Emplace(FString::Format(TEXT("{0}{1}"), { MeshCodeString, SuffixMeshIds[Row + Col * NumAreaColumn] }));
+                    GridCodeIDArray.Emplace(FString::Format(TEXT("{0}{1}"), { GridCodeString, SuffixMeshIds[Row + Col * NumAreaColumn] }));
                 }
             }
         }
     }
-    return MeshIdArray;
+    return GridCodeIDArray;
 }
 
-void FPLATEAUMeshCodeGizmo::SetShowLevel5Mesh(const bool bValue) {
+void FPLATEAUGridCodeGizmo::SetShowLevel5Mesh(const bool bValue) {
     bShowLevel5Mesh = bValue;
 }

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.h
@@ -3,27 +3,27 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include <plateau/dataset/mesh_code.h>
+#include <plateau/dataset/grid_code.h>
 
 namespace plateau {
     namespace geometry {
         class GeoReference;
         constexpr auto ShowFeatureDetailIconCameraDistance = 4000;
         constexpr auto ShowFeatureIconCameraDistance = 9000;
-        constexpr auto ShowRegionMeshIdCameraDistance = 9000;
+        constexpr auto ShowGridCodeIdCameraDistance = 9000;
     }
 }
 
 /**
- * @brief 各地域メッシュのメッシュコードのギズモを表します。
+ * @brief 各グリッドコードのギズモを表します。
  */
-class PLATEAUEDITOR_API FPLATEAUMeshCodeGizmo {
+class PLATEAUEDITOR_API FPLATEAUGridCodeGizmo {
 public:
-    FPLATEAUMeshCodeGizmo();
+    FPLATEAUGridCodeGizmo();
 
     void ResetSelectedArea();
     void DrawExtent(const FSceneView* View, FPrimitiveDrawInterface* PDI) const;
-    void DrawRegionMeshID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& RegionMeshID, double CameraDistance, int IconCount) const;
+    void DrawRegionGridCodeID(const FViewport& InViewport, const FSceneView& View, FCanvas& Canvas, const FString& GridCodeID, double CameraDistance, int IconCount) const;
 
     /**
      * @brief 内部状態から範囲の最小値を取得します。
@@ -46,9 +46,9 @@ public:
     std::shared_ptr<plateau::dataset::GridCode> GetGridCode() const;
     
     /**
-     * @brief メッシュID取得
+     * @brief グリッドコードを文字列で取得
      */
-    FString GetRegionMeshID() const;
+    FString GetRegionGridCodeID() const;
 
     /**
      * @brief 選択状態取得 
@@ -94,9 +94,9 @@ public:
     void SetSelectArea(const double X, const double Y, const bool bSelect);
 
     /**
-     * @brief 選択されているメッシュID配列を取得
+     * @brief 選択されているグリッドコードの文字列の配列を取得
      */
-    TArray<FString> GetSelectedMeshIds();
+    TArray<FString> GetSelectedGridCodeIDs();
     
     /**
      * @brief エリア内の描画有効化状態を設定
@@ -108,7 +108,7 @@ private:
     inline static bool bShowLevel5Mesh = false;
 
     std::shared_ptr<plateau::dataset::GridCode> GridCode;
-    FString MeshCodeString;
+    FString GridCodeString;
     double Width;
     double Height;
     double MinX;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.cpp
@@ -64,7 +64,7 @@ FPLATEAUMeshCodeGizmo::FPLATEAUMeshCodeGizmo() : GridCode(), Width(0), Height(0)
 }
 
 bool FPLATEAUMeshCodeGizmo::IsSelectable() const {
-    return GridCode->isNormalGmlLevel() && GridCode->isSmallerThanNormalGml();
+    return GridCode->isNormalGmlLevel() || GridCode->isSmallerThanNormalGml();
 }
 
 void FPLATEAUMeshCodeGizmo::ResetSelectedArea() {

--- a/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h
@@ -41,9 +41,9 @@ public:
     FVector2D GetSize() const;
 
     /**
-     * @brief メッシュコード取得
+     * @brief グリッドコード取得
      */
-    plateau::dataset::MeshCode GetMeshCode() const;
+    std::shared_ptr<plateau::dataset::GridCode> GetGridCode() const;
     
     /**
      * @brief メッシュID取得
@@ -68,7 +68,7 @@ public:
     /**
      * @brief インスタンスを初期化します。
      */
-    void Init(const plateau::dataset::MeshCode& InMeshCode, const plateau::geometry::GeoReference& InGeoReference);
+    void Init(const std::shared_ptr<plateau::dataset::GridCode>& InGridCode, const plateau::geometry::GeoReference& InGeoReference);
 
     /**
      * @brief マウス座標がエリア内であれば選択状態をトグル
@@ -107,7 +107,7 @@ public:
 private:
     inline static bool bShowLevel5Mesh = false;
 
-    plateau::dataset::MeshCode MeshCode;
+    std::shared_ptr<plateau::dataset::GridCode> GridCode;
     FString MeshCodeString;
     double Width;
     double Height;

--- a/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.cpp
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.cpp
@@ -38,9 +38,9 @@ SPLATEAUExtentEditorViewport::~SPLATEAUExtentEditorViewport() {
         ViewportClient->Viewport = nullptr;
     }
 
-    if (MeshCodeInputWindow.IsValid()) {
-        MeshCodeInputWindow.Pin()->RequestDestroyWindow();
-        MeshCodeInputWindow.Reset();
+    if (GridCodeInputWindow.IsValid()) {
+        GridCodeInputWindow.Pin()->RequestDestroyWindow();
+        GridCodeInputWindow.Reset();
     }
 }
 
@@ -144,7 +144,7 @@ void SPLATEAUExtentEditorViewport::PopulateViewportOverlays(TSharedRef<class SOv
                 SNew(SButton).VAlign(VAlign_Center).ForegroundColor(FColor::White).ButtonStyle(Style.ToSharedRef(), "PLATEAUEditor.FlatButton.Gray").
                 OnClicked_Lambda([this] {
 
-                if (MeshCodeInputWindow.IsValid()) 
+                if (GridCodeInputWindow.IsValid()) 
                     return FReply::Handled();
 
                 //入力Window表示
@@ -157,7 +157,7 @@ void SPLATEAUExtentEditorViewport::PopulateViewportOverlays(TSharedRef<class SOv
                     .FocusWhenFirstShown(true)
                     .IsTopmostWindow(true)
                     .HasCloseButton(false);
-                MeshCodeInputWindow = InputWindow;
+                GridCodeInputWindow = InputWindow;
                 
                 InputWindow->SetContent(
                     SNew(SVerticalBox)
@@ -170,13 +170,13 @@ void SPLATEAUExtentEditorViewport::PopulateViewportOverlays(TSharedRef<class SOv
                     + SVerticalBox::Slot()
                     .AutoHeight().Padding(FMargin(5.f, 8.f, 5.f, 8.f))
                     [
-                        SAssignNew(MeshCodeTextBox, SEditableTextBox)
+                        SAssignNew(GridCodeTextBox, SEditableTextBox)
                         .HintText(FText::FromString(TEXT("メッシュコード")))
                     ]
                     + SVerticalBox::Slot()
                     .AutoHeight().Padding(FMargin(5.f, 2.f, 5.f, 2.f))
                     [
-                        SAssignNew(MeshCodeErrorText, STextBlock)
+                        SAssignNew(GridCodeErrorText, STextBlock)
                         .ColorAndOpacity(FLinearColor::Red)
                         .Text(FText())
                     ]
@@ -191,9 +191,9 @@ void SPLATEAUExtentEditorViewport::PopulateViewportOverlays(TSharedRef<class SOv
                             .Text(FText::FromString(TEXT("キャンセル"))).
                             OnClicked_Lambda([this] {
                                 //Windowを閉じる
-                                if (MeshCodeInputWindow.IsValid()) {
-                                    MeshCodeInputWindow.Pin()->RequestDestroyWindow();
-                                    MeshCodeInputWindow.Reset();
+                                if (GridCodeInputWindow.IsValid()) {
+                                    GridCodeInputWindow.Pin()->RequestDestroyWindow();
+                                    GridCodeInputWindow.Reset();
                                 }
                                 return FReply::Handled();
                             })
@@ -205,24 +205,24 @@ void SPLATEAUExtentEditorViewport::PopulateViewportOverlays(TSharedRef<class SOv
                                 .Text(FText::FromString(TEXT("OK"))).
                                 OnClicked_Lambda([this] {
                                     //メッシュコードの位置を表示
-                                    FText Value = MeshCodeTextBox.Pin()->GetText();
+                                    FText Value = GridCodeTextBox.Pin()->GetText();
                                     FString meshcode = Value.ToString();
                                     if (!meshcode.IsNumeric()) {
-                                        if(MeshCodeErrorText.IsValid())
-                                            MeshCodeErrorText.Pin()->SetText(FText::FromString(TEXT("数字を入力してください")));
+                                        if(GridCodeErrorText.IsValid())
+                                            GridCodeErrorText.Pin()->SetText(FText::FromString(TEXT("数字を入力してください")));
                                     }
                                     else if (meshcode.Len() != 6 && meshcode.Len() != 8) {
-                                        if (MeshCodeErrorText.IsValid())
-                                            MeshCodeErrorText.Pin()->SetText(FText::FromString(TEXT("6桁または８桁の数字を入力してください")));
+                                        if (GridCodeErrorText.IsValid())
+                                            GridCodeErrorText.Pin()->SetText(FText::FromString(TEXT("6桁または８桁の数字を入力してください")));
                                     }
                                     else if (!ViewportClient->SetViewLocationByGridCode(meshcode)) {
-                                        if (MeshCodeErrorText.IsValid())
-                                            MeshCodeErrorText.Pin()->SetText(FText::FromString(TEXT("メッシュコードが範囲外です")));
+                                        if (GridCodeErrorText.IsValid())
+                                            GridCodeErrorText.Pin()->SetText(FText::FromString(TEXT("メッシュコードが範囲外です")));
                                     }
                                     else {
-                                        if (MeshCodeInputWindow.IsValid()) {
-                                            MeshCodeInputWindow.Pin()->RequestDestroyWindow();
-                                            MeshCodeInputWindow.Reset();
+                                        if (GridCodeInputWindow.IsValid()) {
+                                            GridCodeInputWindow.Pin()->RequestDestroyWindow();
+                                            GridCodeInputWindow.Reset();
                                         }
                                     }     
                                     return FReply::Handled();

--- a/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.h
+++ b/Source/PLATEAUEditor/Private/ExtentEditor/SPLATEAUExtentEditorViewport.h
@@ -42,7 +42,7 @@ private:
     // エディタースタイル
     TSharedPtr<FPLATEAUEditorStyle> Style;
     //メッシュコード入力パネル
-    TWeakPtr<SWindow> MeshCodeInputWindow;
-    TWeakPtr<SEditableTextBox> MeshCodeTextBox;
-    TWeakPtr<STextBlock> MeshCodeErrorText;
+    TWeakPtr<SWindow> GridCodeInputWindow;
+    TWeakPtr<SEditableTextBox> GridCodeTextBox;
+    TWeakPtr<STextBlock> GridCodeErrorText;
 };

--- a/Source/PLATEAUEditor/Public/ExtentEditor/PLATEAUExtentEditor.h
+++ b/Source/PLATEAUEditor/Public/ExtentEditor/PLATEAUExtentEditor.h
@@ -39,9 +39,9 @@ public:
 
     bool IsSelectedArea() const;
     TArray<FString> GetSelectedCodes(const bool InbImportFromServer) const;
-    TMap<FString, FPLATEAUGridCodeGizmo> GetAreaMeshCodeMap() const;
-    void SetAreaMeshCodeMap(const FString& MeshCode, const FPLATEAUGridCodeGizmo& MeshCodeGizmo);
-    void ResetAreaMeshCodeMap();
+    TMap<FString, FPLATEAUGridCodeGizmo> GetGridCodeMap() const;
+    void SetGridCodeMap(const FString& MeshCode, const FPLATEAUGridCodeGizmo& MeshCodeGizmo);
+    void ResetGridCodeMap();
 
     FPLATEAUGeoReference GetGeoReference() const;
     void SetGeoReference(const FPLATEAUGeoReference& InGeoReference);

--- a/Source/PLATEAUEditor/Public/ExtentEditor/PLATEAUExtentEditor.h
+++ b/Source/PLATEAUEditor/Public/ExtentEditor/PLATEAUExtentEditor.h
@@ -5,7 +5,7 @@
 #include "CoreMinimal.h"
 #include "AdvancedPreviewSceneModule.h"
 #include "PLATEAUGeometry.h"
-#include "PLATEAUEditor/Private/ExtentEditor/PLATEAUMeshCodeGizmo.h"
+#include "PLATEAUEditor/Private/ExtentEditor/PLATEAUGridCodeGizmo.h"
 #include <plateau/network/client.h>
 
 class SDockTab;
@@ -39,8 +39,8 @@ public:
 
     bool IsSelectedArea() const;
     TArray<FString> GetSelectedCodes(const bool InbImportFromServer) const;
-    TMap<FString, FPLATEAUMeshCodeGizmo> GetAreaMeshCodeMap() const;
-    void SetAreaMeshCodeMap(const FString& MeshCode, const FPLATEAUMeshCodeGizmo& MeshCodeGizmo);
+    TMap<FString, FPLATEAUGridCodeGizmo> GetAreaMeshCodeMap() const;
+    void SetAreaMeshCodeMap(const FString& MeshCode, const FPLATEAUGridCodeGizmo& MeshCodeGizmo);
     void ResetAreaMeshCodeMap();
 
     FPLATEAUGeoReference GetGeoReference() const;
@@ -69,8 +69,8 @@ public:
 private:
     FString SourcePath;
     FString AreaSourcePath;
-    TMap<FString, FPLATEAUMeshCodeGizmo> LocalAreaMeshCodeMap;
-    TMap<FString, FPLATEAUMeshCodeGizmo> ServerAreaMeshCodeMap;
+    TMap<FString, FPLATEAUGridCodeGizmo> LocalAreaMeshCodeMap;
+    TMap<FString, FPLATEAUGridCodeGizmo> ServerAreaMeshCodeMap;
     FPLATEAUGeoReference GeoReference;
 
     bool bImportFromServer = false;

--- a/Source/PLATEAUEditorBPLibraries/Private/Import/PLATEAUImportModelBtn.cpp
+++ b/Source/PLATEAUEditorBPLibraries/Private/Import/PLATEAUImportModelBtn.cpp
@@ -30,7 +30,7 @@ APLATEAUCityModelLoader* UPLATEAUImportModelBtn::GetCityModelLoader(const int Zo
         Loader->Source = ExtentEditor->GetSourcePath();
     }
 
-    Loader->MeshCodes = IPLATEAUEditorModule::Get().GetExtentEditor()->GetSelectedCodes(bImportFromServer);
+    Loader->GridCodes = IPLATEAUEditorModule::Get().GetExtentEditor()->GetSelectedCodes(bImportFromServer);
 
     Loader->GeoReference.ZoneID = ZoneID;
     Loader->GeoReference.ReferencePoint = ReferencePoint;

--- a/Source/PLATEAURuntime/Private/PLATEAUCityModelLoader.cpp
+++ b/Source/PLATEAURuntime/Private/PLATEAUCityModelLoader.cpp
@@ -48,10 +48,9 @@ public:
                 auto& LoadInputData = LoadInputDataArray.AddDefaulted_GetRef();
                 LoadInputData.GmlPath = UTF8_TO_TCHAR(GmlFile.getPath().c_str());
 
-                // メッシュコードからインポート範囲に変換
-                for (const auto& StrGridCode : StrGridCodes) {
-                    const auto RawExtent = plateau::dataset::GridCode::create(TCHAR_TO_UTF8(*StrGridCode))->getExtent();
-                    LoadInputData.Extents.push_back(RawExtent);
+                // グリッドコードからインポート範囲に変換
+                for (const auto& GridCode : NativeGridCodes) {
+                    LoadInputData.Extents.push_back(GridCode->getExtent());
                 }
 
                 LoadInputData.bIncludeAttrInfo = Settings.bIncludeAttrInfo;

--- a/Source/PLATEAURuntime/Public/PLATEAUCityModelLoader.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUCityModelLoader.h
@@ -88,7 +88,7 @@ public:
         FString Source;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU")
-        TArray<FString> MeshCodes;
+        TArray<FString> GridCodes;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU")
         FPLATEAUGeoReference GeoReference;

--- a/Source/PLATEAURuntime/Public/PLATEAUInstancedCityModel.h
+++ b/Source/PLATEAURuntime/Public/PLATEAUInstancedCityModel.h
@@ -100,7 +100,7 @@ public:
         TObjectPtr<class APLATEAUCityModelLoader> Loader;
 
     UPROPERTY(EditAnywhere, Category = "PLATEAU")
-        TArray<FString> MeshCodes;
+        TArray<FString> GridCodes;
 
     UFUNCTION(BlueprintGetter)
         double GetLatitude();

--- a/Source/PLATEAURuntimeBPLibraries/Private/Import/PLATEAUImportModelRuntimeAPI.cpp
+++ b/Source/PLATEAURuntimeBPLibraries/Private/Import/PLATEAUImportModelRuntimeAPI.cpp
@@ -8,20 +8,20 @@
 
 namespace {
 
-    APLATEAUCityModelLoader* GetCityModelLoader(UWorld* World, const TArray<FString> MeshCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData, plateau::dataset::DatasetSource InDatasetSource) {
+    APLATEAUCityModelLoader* GetCityModelLoader(UWorld* World, const TArray<FString> StrGridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData, plateau::dataset::DatasetSource InDatasetSource) {
         FActorSpawnParameters SpawnParam;
         const auto Actor = World->SpawnActor<APLATEAUCityModelLoader>(SpawnParam);
         const auto Loader = Cast<APLATEAUCityModelLoader>(Actor);
-        Loader->MeshCodes = MeshCodes;
+        Loader->GridCodes = StrGridCodes;
         Loader->GeoReference.ZoneID = ZoneID;
         Loader->GeoReference.ReferencePoint = ReferencePoint;
         Loader->GeoReference.UpdateNativeData();
 
-        std::vector<plateau::dataset::MeshCode> NativeSelectedMeshCodes;
-        for (const auto& Code : MeshCodes) {
-            NativeSelectedMeshCodes.emplace_back(TCHAR_TO_UTF8(*Code));
+        std::vector<std::shared_ptr<plateau::dataset::GridCode>> NativeSelectedGridCodes;
+        for (const auto& Code : StrGridCodes) {
+            NativeSelectedGridCodes.push_back(plateau::dataset::GridCode::create(TCHAR_TO_UTF8(*Code)));
         }
-        const auto FilteredDatasetAccessor = InDatasetSource.getAccessor()->filterByMeshCodes(NativeSelectedMeshCodes);
+        const auto FilteredDatasetAccessor = InDatasetSource.getAccessor()->filterByGridCodes(NativeSelectedGridCodes);
         const auto PackageMask = FilteredDatasetAccessor->getPackages();
         const auto ImportSettings = DuplicateObject(GetMutableDefault<UPLATEAUImportSettings>(), Loader);
         for (const auto& Package : UPLATEAUImportSettings::GetAllPackages()) {

--- a/Source/PLATEAURuntimeBPLibraries/Private/Import/PLATEAUImportModelRuntimeAPI.cpp
+++ b/Source/PLATEAURuntimeBPLibraries/Private/Import/PLATEAUImportModelRuntimeAPI.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 
-    APLATEAUCityModelLoader* GetCityModelLoader(UWorld* World, const TArray<FString> StrGridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData, plateau::dataset::DatasetSource InDatasetSource) {
+    APLATEAUCityModelLoader* GetCityModelLoader(UWorld* World, const TArray<FString>& StrGridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData, plateau::dataset::DatasetSource InDatasetSource) {
         FActorSpawnParameters SpawnParam;
         const auto Actor = World->SpawnActor<APLATEAUCityModelLoader>(SpawnParam);
         const auto Loader = Cast<APLATEAUCityModelLoader>(Actor);
@@ -54,7 +54,7 @@ namespace {
     }
 }
 
-APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderLocal(const UObject* Context, const FString& SourcePath, const TArray<FString> MeshCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData) {
+APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderLocal(const UObject* Context, const FString& SourcePath, const TArray<FString> GridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData) {
 
 #if !WITH_EDITOR
     FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("この機能は、エディタのみでご利用いただけます。")));
@@ -64,7 +64,7 @@ APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderLocal(
     try {
         const auto World = Context->GetWorld();
         const auto InDatasetSource = plateau::dataset::DatasetSource::createLocal(TCHAR_TO_UTF8(*SourcePath));
-        const auto Loader = GetCityModelLoader(World, MeshCodes, ZoneID, ReferencePoint, PackageInfoSettingsData, InDatasetSource);
+        const auto Loader = GetCityModelLoader(World, GridCodes, ZoneID, ReferencePoint, PackageInfoSettingsData, InDatasetSource);
 
         // ClientPtrは何か設定しないとクラッシュします
         Loader->ClientPtr = std::make_shared<plateau::network::Client>("", "");
@@ -78,7 +78,7 @@ APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderLocal(
     }       
 }
 
-APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderServer(const UObject* Context, const FString& InServerURL, const FString& InToken, const FString& DatasetID, const TArray<FString> MeshCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData) {
+APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderServer(const UObject* Context, const FString& InServerURL, const FString& InToken, const FString& DatasetID, const TArray<FString> GridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData) {
  
 #if !WITH_EDITOR
     FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(TEXT("この機能は、エディタのみでご利用いただけます。")));
@@ -89,7 +89,7 @@ APLATEAUCityModelLoader* UPLATEAUImportModelRuntimeAPI::GetCityModelLoaderServer
         const auto World = Context->GetWorld();
         const auto ClientPtr = std::make_shared<plateau::network::Client>(TCHAR_TO_UTF8(*InServerURL), TCHAR_TO_UTF8(*InToken));
         const auto InDatasetSource = plateau::dataset::DatasetSource::createServer(TCHAR_TO_UTF8(*DatasetID), *ClientPtr);
-        const auto Loader = GetCityModelLoader(World, MeshCodes, ZoneID, ReferencePoint, PackageInfoSettingsData, InDatasetSource);
+        const auto Loader = GetCityModelLoader(World, GridCodes, ZoneID, ReferencePoint, PackageInfoSettingsData, InDatasetSource);
   
         Loader->ClientPtr = ClientPtr;
         Loader->Source = DatasetID;

--- a/Source/PLATEAURuntimeBPLibraries/Public/Import/PLATEAUImportModelRuntimeAPI.h
+++ b/Source/PLATEAURuntimeBPLibraries/Public/Import/PLATEAUImportModelRuntimeAPI.h
@@ -15,9 +15,9 @@ class PLATEAURUNTIMEBPLIBRARIES_API UPLATEAUImportModelRuntimeAPI : public UBlue
     GENERATED_BODY()
 public:
     UFUNCTION(BlueprintCallable, meta = (WorldContext = "Context"), Category = "PLATEAU|BPLibraries|ImportAPI")
-    static APLATEAUCityModelLoader* GetCityModelLoaderLocal(const UObject* Context, const FString& SourcePath, const TArray<FString> MeshCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData);
+    static APLATEAUCityModelLoader* GetCityModelLoaderLocal(const UObject* Context, const FString& SourcePath, const TArray<FString> GridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData);
 
     UFUNCTION(BlueprintCallable, meta = (WorldContext = "Context"), Category = "PLATEAU|BPLibraries|ImportAPI")
-    static APLATEAUCityModelLoader* GetCityModelLoaderServer(const UObject* Context, const FString& InServerURL, const FString& InToken, const FString& DatasetID, const TArray<FString> MeshCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData);
+    static APLATEAUCityModelLoader* GetCityModelLoaderServer(const UObject* Context, const FString& InServerURL, const FString& InToken, const FString& DatasetID, const TArray<FString> GridCodes, const int ZoneID, const FVector& ReferencePoint, const TMap<EPLATEAUCityModelPackage, FPackageInfoSettings>& PackageInfoSettingsData);
 
 };

--- a/Source/PLATEAUTests/Tests/PLATEAUAutomationTestBase.h
+++ b/Source/PLATEAUTests/Tests/PLATEAUAutomationTestBase.h
@@ -44,20 +44,20 @@ class FPLATEAUAutomationTestBase : public FAutomationTestBase {
     
         const auto DatasetSource = plateau::dataset::DatasetSource::createLocal(TCHAR_TO_UTF8(*SourcePath));
         const std::shared_ptr<plateau::dataset::IDatasetAccessor> DatasetAccessor = DatasetSource.getAccessor();
-        if (DatasetAccessor == nullptr || DatasetAccessor->getMeshCodes().size() == 0)
+        if (DatasetAccessor == nullptr || DatasetAccessor->getGridCodes().size() == 0)
             return nullptr;
     
         const plateau::geometry::GeoReference RawGeoReference(ZoneId, {}, 1, plateau::geometry::CoordinateSystem::ESU);
         ExtentEditor->SetGeoReference(RawGeoReference);
 
-        const auto& MeshCodes = DatasetAccessor->getMeshCodes();
+        const auto& GridCodes = DatasetAccessor->getGridCodes();
         auto GeoReference = ExtentEditor->GetGeoReference();
         TArray<FPLATEAUMeshCodeGizmo> MeshCodeGizmos;
         TArray<bool> bSelectedArray;
         MeshCodeGizmos.Reset();
-        for (const auto& MeshCode : MeshCodes) {
+        for (const auto& GridCode : GridCodes) {
             MeshCodeGizmos.AddDefaulted();
-            MeshCodeGizmos.Last().Init(MeshCode, GeoReference.GetData());
+            MeshCodeGizmos.Last().Init(GridCode, GeoReference.GetData());
             if ("53392642" != MeshCodeGizmos.Last().GetRegionMeshID())
                 continue;
             
@@ -66,7 +66,7 @@ class FPLATEAUAutomationTestBase : public FAutomationTestBase {
                 bSelectedArray.Emplace(true);
             }
             MeshCodeGizmos.Last().SetbSelectedArray(bSelectedArray);
-            IPLATEAUEditorModule::Get().GetExtentEditor()->SetAreaMeshCodeMap(TCHAR_TO_UTF8(MeshCode.get().c_str()), MeshCodeGizmos.Last());
+            IPLATEAUEditorModule::Get().GetExtentEditor()->SetAreaMeshCodeMap(TCHAR_TO_UTF8(GridCode->get().c_str()), MeshCodeGizmos.Last());
         }
         
         return UPLATEAUImportModelBtn::GetCityModelLoader(ZoneId, ReferencePoint, PackageInfoSettingsData, false);

--- a/Source/PLATEAUTests/Tests/PLATEAUAutomationTestBase.h
+++ b/Source/PLATEAUTests/Tests/PLATEAUAutomationTestBase.h
@@ -52,13 +52,13 @@ class FPLATEAUAutomationTestBase : public FAutomationTestBase {
 
         const auto& GridCodes = DatasetAccessor->getGridCodes();
         auto GeoReference = ExtentEditor->GetGeoReference();
-        TArray<FPLATEAUMeshCodeGizmo> MeshCodeGizmos;
+        TArray<FPLATEAUGridCodeGizmo> MeshCodeGizmos;
         TArray<bool> bSelectedArray;
         MeshCodeGizmos.Reset();
         for (const auto& GridCode : GridCodes) {
             MeshCodeGizmos.AddDefaulted();
             MeshCodeGizmos.Last().Init(GridCode, GeoReference.GetData());
-            if ("53392642" != MeshCodeGizmos.Last().GetRegionMeshID())
+            if ("53392642" != MeshCodeGizmos.Last().GetRegionGridCodeID())
                 continue;
             
             bSelectedArray.Reset();

--- a/Source/PLATEAUTests/Tests/PLATEAUAutomationTestBase.h
+++ b/Source/PLATEAUTests/Tests/PLATEAUAutomationTestBase.h
@@ -66,7 +66,7 @@ class FPLATEAUAutomationTestBase : public FAutomationTestBase {
                 bSelectedArray.Emplace(true);
             }
             MeshCodeGizmos.Last().SetbSelectedArray(bSelectedArray);
-            IPLATEAUEditorModule::Get().GetExtentEditor()->SetAreaMeshCodeMap(TCHAR_TO_UTF8(GridCode->get().c_str()), MeshCodeGizmos.Last());
+            IPLATEAUEditorModule::Get().GetExtentEditor()->SetGridCodeMap(TCHAR_TO_UTF8(GridCode->get().c_str()), MeshCodeGizmos.Last());
         }
         
         return UPLATEAUImportModelBtn::GetCityModelLoader(ZoneId, ReferencePoint, PackageInfoSettingsData, false);

--- a/Source/ThirdParty/include/plateau/dataset/gml_file.h
+++ b/Source/ThirdParty/include/plateau/dataset/gml_file.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include "plateau/network/client.h"
 #include "city_model_package.h"
+#include "plateau/dataset/grid_code.h"
 
 namespace plateau::dataset {
 
@@ -20,7 +21,11 @@ namespace plateau::dataset {
         const std::string& getPath() const;
         void setPath(const std::string& path);
         std::shared_ptr<GridCode> getGridCode() const;
-        GridCode* getGridCodeRaw() const; // 寿命管理をDLL利用者に任せる用です
+        /**
+         * getGridCode関数をP/Invokeで利用するための生ポインタ版です。
+         * 新しいGridCodeインスタンスを生成して返すので、DLL利用者が廃棄する必要があります。
+         */
+        GridCode* getGridCodeRaw() const;
         double getEpsg() const;
         bool isPolarCoordinateSystem() const;
         const std::string& getFeatureType() const;

--- a/Source/ThirdParty/include/plateau/dataset/gml_file.h
+++ b/Source/ThirdParty/include/plateau/dataset/gml_file.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <libplateau_api.h>
-#include <plateau/dataset/mesh_code.h>
 #include <set>
 #include <optional>
 #include "plateau/network/client.h"
@@ -20,7 +19,10 @@ namespace plateau::dataset {
 
         const std::string& getPath() const;
         void setPath(const std::string& path);
-        MeshCode getMeshCode() const;
+        std::shared_ptr<GridCode> getGridCode() const;
+        GridCode* getGridCodeRaw() const; // 寿命管理をDLL利用者に任せる用です
+        double getEpsg() const;
+        bool isPolarCoordinateSystem() const;
         const std::string& getFeatureType() const;
         PredefinedCityModelPackage getPackage() const;
         std::string getAppearanceDirectoryPath() const;
@@ -61,8 +63,9 @@ namespace plateau::dataset {
 
     private:
         std::string path_;
-        std::string code_;
+        std::shared_ptr<GridCode> grid_code_;
         std::string feature_type_;
+        std::string epsg_;
         bool is_valid_;
         bool is_local_;
         int max_lod_;

--- a/Source/ThirdParty/include/plateau/dataset/grid_code.h
+++ b/Source/ThirdParty/include/plateau/dataset/grid_code.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include <libplateau_api.h>
+#include "plateau/geometry/geo_coordinate.h"
+
+namespace plateau::dataset {
+    class StandardMapGrid;
+    class MeshCode;
+
+    /**
+     * \brief 地図の区画を表すコードの基底クラスです。
+     * 
+     * メッシュコードや国土基本図図郭など、地図の区画を表現するコードシステムの共通機能を提供します。
+     */
+    class LIBPLATEAU_EXPORT GridCode {
+    public:
+        virtual ~GridCode() = default;
+
+        /**
+         * \brief コードを文字列として取得します。
+         */
+        virtual std::string get() const = 0;
+
+        /**
+         * \brief コードが表す緯度経度範囲を取得します。
+         */
+        virtual geometry::Extent getExtent() const = 0;
+
+        /**
+         * \brief コードが適切な値かどうかを返します。
+         */
+        virtual bool isValid() const = 0;
+
+        /**
+         * \brief １段階上のレベルのグリッドコードに変換します。
+         */
+        virtual std::shared_ptr<GridCode> upper() const = 0;
+
+        /**
+         * \brief upper()のP/Invokeから呼び出す版です。newして返すので、利用者が適切に廃棄する必要があります。
+         */
+        virtual GridCode* upperRaw() const = 0;
+
+        /**
+         * \brief コードのレベル（詳細度）を取得します。
+         */
+        virtual int getLevel() const = 0;
+
+        /**
+         * \brief コードのレベル（詳細度）が、PLATEAUの仕様上考えられる中でもっとも広域であるときにtrueを返します。
+         */
+        virtual bool isLargestLevel() const = 0;
+
+        /**
+         * \brief コードのレベル（詳細度）が、PLATEAUの典型的な建物のGMLファイルのレベルよりも詳細である場合にtrueを返します。
+         */
+        virtual bool isSmallerThanNormalGml() const = 0;
+
+        /**
+         * \brief コードのレベル（詳細度）が、PLATEAUの典型的な建物のGMLファイルのレベルである場合にtrueを返します。
+         */
+        virtual bool isNormalGmlLevel() const = 0;
+
+
+        /**
+         * \brief 与えられたコードから適切なGridCodeの派生クラスのインスタンスを作成します。
+         * \param code コード文字列
+         * \return コードの形式に応じてMeshCodeまたはStandardMapGridのインスタンスを返します。
+         * \throw std::invalid_argument コードの形式が不正な場合
+         */
+        static std::shared_ptr<GridCode> create(const std::string& code);
+
+        /**
+         * \brief 与えられたコードから適切なGridCodeの派生クラスのインスタンスを作成します。
+         * \param code コード文字列
+         * \return コードの形式に応じてMeshCodeまたはStandardMapGridのインスタンスを返します。生ポインタで返されます。
+         * \throw std::invalid_argument コードの形式が不正な場合
+         */
+        static GridCode* createRaw(const std::string& code);
+
+    };
+
+    struct GridCodeComparator {
+        bool operator()(const std::shared_ptr<GridCode>& lhs, const std::shared_ptr<GridCode>& rhs) const {
+            if(lhs == nullptr && rhs == nullptr) return false;
+            if(lhs != nullptr && rhs == nullptr) return false;
+            if(lhs == nullptr) return true;
+            return lhs->get() < rhs->get();
+        }
+    };
+} 

--- a/Source/ThirdParty/include/plateau/dataset/grid_code.h
+++ b/Source/ThirdParty/include/plateau/dataset/grid_code.h
@@ -73,7 +73,7 @@ namespace plateau::dataset {
         static std::shared_ptr<GridCode> create(const std::string& code);
 
         /**
-         * \brief 与えられたコードから適切なGridCodeの派生クラスのインスタンスを作成します。
+         * \brief create()をUnityのP/Invokeから呼び出す版です。newして返すので、利用者が適切に廃棄する必要があります。
          * \param code コード文字列
          * \return コードの形式に応じてMeshCodeまたはStandardMapGridのインスタンスを返します。生ポインタで返されます。
          * \throw std::invalid_argument コードの形式が不正な場合

--- a/Source/ThirdParty/include/plateau/dataset/i_dataset_accessor.h
+++ b/Source/ThirdParty/include/plateau/dataset/i_dataset_accessor.h
@@ -3,6 +3,8 @@
 #include <libplateau_api.h>
 #include <plateau/dataset/gml_file.h>
 #include <plateau/dataset/city_model_package.h>
+#include <plateau/dataset/grid_code.h>
+#include <memory>
 
 namespace plateau::geometry {
     class GeoReference;
@@ -14,7 +16,7 @@ namespace plateau::dataset {
      */
     class LIBPLATEAU_EXPORT UdxSubFolder {
     public:
-        UdxSubFolder(std::string name)
+        explicit UdxSubFolder(std::string name)
             : name_(std::move(name)) {
         }
 
@@ -25,11 +27,11 @@ namespace plateau::dataset {
             return name_;
         }
 
-        operator std::string& () {
+        explicit operator std::string& () {
             return name_;
         }
 
-        operator std::string() const {
+        explicit operator std::string() const {
             return name_;
         }
 
@@ -93,9 +95,9 @@ namespace plateau::dataset {
          * \brief GMLファイル群のうち、範囲が extent の内部であり、パッケージ種が package であるものを vector で返します。
          * なお、 package はフラグの集合と見なされるので、複数のビットを立てることで複数の指定が可能です。
          */
-         virtual std::shared_ptr<std::vector<GmlFile>> getGmlFiles(const PredefinedCityModelPackage package) = 0;
+         virtual std::shared_ptr<std::vector<GmlFile>> getGmlFiles(PredefinedCityModelPackage package) = 0;
 
-         virtual void getGmlFiles(const PredefinedCityModelPackage package,
+         virtual void getGmlFiles(PredefinedCityModelPackage package,
                                   std::vector<GmlFile>& out_vector) = 0;
 
          /**
@@ -114,22 +116,23 @@ namespace plateau::dataset {
 
         /**
          * \brief メッシュコードで都市モデルデータをフィルタリングします。
-         * \param mesh_codes 欲しい地域IDのvector
+         * \param grid_codes 欲しい地域IDのvector
          * \param collection フィルタリングされた都市モデルデータの格納先
          */
-        virtual void filterByMeshCodes(const std::vector<MeshCode>& mesh_codes, IDatasetAccessor& collection) const = 0;
+        virtual void filterByGridCodes(const std::vector<GridCode*>& grid_codes, IDatasetAccessor& collection) const = 0;
 
         /**
          * \brief メッシュコードで都市モデルデータをフィルタリングします。
-         * \param mesh_codes 欲しい地域IDのvector
+         * \param grid_codes 欲しい地域IDのvector
          * \return フィルタリングされた都市モデルデータ
          */
-        virtual std::shared_ptr<IDatasetAccessor> filterByMeshCodes(const std::vector<MeshCode>& mesh_codes) const = 0;
+        virtual std::shared_ptr<IDatasetAccessor> filterByGridCodes(
+                const std::vector<std::shared_ptr<GridCode>>& grid_codes) const = 0;
 
         /**
          * \brief 都市モデルデータが存在する地域メッシュのリストを取得します。
          */
-        virtual std::set<MeshCode>& getMeshCodes() = 0;
+        virtual std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() = 0;
 
         virtual TVec3d calculateCenterPoint(const plateau::geometry::GeoReference& geo_reference) = 0;
 

--- a/Source/ThirdParty/include/plateau/dataset/i_dataset_accessor.h
+++ b/Source/ThirdParty/include/plateau/dataset/i_dataset_accessor.h
@@ -27,10 +27,6 @@ namespace plateau::dataset {
             return name_;
         }
 
-        explicit operator std::string& () {
-            return name_;
-        }
-
         explicit operator std::string() const {
             return name_;
         }
@@ -114,12 +110,6 @@ namespace plateau::dataset {
          */
         virtual std::shared_ptr<IDatasetAccessor> filter(const geometry::Extent& extent) const = 0;
 
-        /**
-         * \brief メッシュコードで都市モデルデータをフィルタリングします。
-         * \param grid_codes 欲しい地域IDのvector
-         * \param collection フィルタリングされた都市モデルデータの格納先
-         */
-        virtual void filterByGridCodes(const std::vector<GridCode*>& grid_codes, IDatasetAccessor& collection) const = 0;
 
         /**
          * \brief メッシュコードで都市モデルデータをフィルタリングします。
@@ -128,6 +118,11 @@ namespace plateau::dataset {
          */
         virtual std::shared_ptr<IDatasetAccessor> filterByGridCodes(
                 const std::vector<std::shared_ptr<GridCode>>& grid_codes) const = 0;
+
+        /**
+         * \brief filterByGridCodes関数の、UnityでP/Invokeから呼び出す版です。引数のvector内のポインタの廃棄はDLL側で責任を持ってください。
+         */
+        virtual void filterByGridCodes(const std::vector<GridCode*>& grid_codes, IDatasetAccessor& collection) const = 0;
 
         /**
          * \brief 都市モデルデータが存在する地域メッシュのリストを取得します。

--- a/Source/ThirdParty/include/plateau/dataset/i_dataset_accessor.h
+++ b/Source/ThirdParty/include/plateau/dataset/i_dataset_accessor.h
@@ -132,7 +132,7 @@ namespace plateau::dataset {
         /**
          * \brief 都市モデルデータが存在する地域メッシュのリストを取得します。
          */
-        virtual std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() = 0;
+        virtual const std::set<std::shared_ptr<GridCode>, GridCodeComparator>& getGridCodes() = 0;
 
         virtual TVec3d calculateCenterPoint(const plateau::geometry::GeoReference& geo_reference) = 0;
 

--- a/Source/ThirdParty/include/plateau/dataset/invalid_grid_code.h
+++ b/Source/ThirdParty/include/plateau/dataset/invalid_grid_code.h
@@ -46,6 +46,9 @@ namespace plateau::dataset {
             return std::make_shared<InvalidGridCode>(); 
         }
 
+        /**
+         * InvalidGridCodeをnewして返します。DLLの利用者が廃棄に責任を持つ必要があります。
+         */
         GridCode* upperRaw() const override {
             return new InvalidGridCode();
         }

--- a/Source/ThirdParty/include/plateau/dataset/invalid_grid_code.h
+++ b/Source/ThirdParty/include/plateau/dataset/invalid_grid_code.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <libplateau_api.h>
+#include "plateau/dataset/grid_code.h"
+#include "plateau/geometry/geo_coordinate.h"
+
+namespace plateau::dataset {
+    /**
+     * \brief 無効なグリッドコードを表すクラスです。
+     * 
+     * GridCodeの派生クラスとして、無効なグリッドコードを表現します。
+     * このクラスのインスタンスは常に無効（isValid() == false）です。
+     */
+    class LIBPLATEAU_EXPORT InvalidGridCode : public GridCode {
+    public:
+        InvalidGridCode() = default;
+
+        /**
+         * \brief 無効なグリッドコードを文字列として取得します。
+         * \return 常に空文字列を返します。
+         */
+        std::string get() const override { return ""; }
+
+        /**
+         * \brief 無効なグリッドコードの緯度経度範囲を取得します。
+         * \return 原点（0,0,0）を中心とする無効な範囲を返します。
+         */
+        geometry::Extent getExtent() const override {
+            return {
+                geometry::GeoCoordinate(0, 0, 0),
+                geometry::GeoCoordinate(0, 0, 0)
+            };
+        }
+
+        /**
+         * \brief コードが適切な値かどうかを返します。
+         * \return 常にfalseを返します。
+         */
+        bool isValid() const override { return false; }
+
+        /**
+         * \brief １段階上のレベルのグリッドコードに変換します。
+         * \return 無効なグリッドコードを返します。
+         */
+        std::shared_ptr<GridCode> upper() const override {
+            return std::make_shared<InvalidGridCode>(); 
+        }
+
+        GridCode* upperRaw() const override {
+            return new InvalidGridCode();
+        }
+
+        int getLevel() const override { return -1; }
+        bool isLargestLevel() const override { return true; }
+        bool isSmallerThanNormalGml() const override { return false; }
+        bool isNormalGmlLevel() const override { return true; }
+    };
+} 

--- a/Source/ThirdParty/include/plateau/dataset/mesh_code.h
+++ b/Source/ThirdParty/include/plateau/dataset/mesh_code.h
@@ -5,6 +5,7 @@
 
 #include <libplateau_api.h>
 #include "plateau/geometry/geo_coordinate.h"
+#include "plateau/dataset/grid_code.h"
 
 namespace plateau::dataset {
     /**
@@ -12,7 +13,7 @@ namespace plateau::dataset {
      * 
      * 2~5次メッシュの緯度経度範囲の取得、緯度経度範囲を内包する3次メッシュの取得を行う機能を提供しています。
      */
-    class LIBPLATEAU_EXPORT MeshCode {
+class LIBPLATEAU_EXPORT MeshCode : public plateau::dataset::GridCode {
     public:
         explicit MeshCode(const std::string& code);
         MeshCode() = default;
@@ -20,17 +21,17 @@ namespace plateau::dataset {
         /**
          * \brief メッシュコードを文字列として取得します。
          */
-        std::string get() const;
+        std::string get() const override;
 
         /**
          * \brief メッシュコードの次数を取得します。
          */
-        int getLevel() const;
+        int getLevel() const override;
 
         /**
          * \brief メッシュコードの緯度経度範囲を取得します。
          */
-        geometry::Extent getExtent() const;
+        geometry::Extent getExtent() const override;
 
         /**
          * \brief 座標点を含む3次メッシュを取得します。
@@ -48,11 +49,6 @@ namespace plateau::dataset {
         static std::shared_ptr<std::vector<MeshCode>> getThirdMeshes(const geometry::Extent& extent);
 
         /**
-         * \brief 地域メッシュが内包されるかどうかを計算します。
-         */
-        bool isWithin(const MeshCode& other) const;
-
-        /**
          * \brief 地域メッシュを2次メッシュとして取得します。
         */
         MeshCode asSecond() const;
@@ -60,32 +56,38 @@ namespace plateau::dataset {
         /**
          * \brief レベル2以上の範囲で１段階上のレベルの地域メッシュに変換します。
         */
-        MeshCode& upper();
+        std::shared_ptr<GridCode> upper() const override;
+        GridCode* upperRaw() const override;
 
         /**
          * \brief メッシュコードが適切な値かどうかを返します。
         */
-        bool isValid() const;
+        bool isValid() const override;
+
+        /**
+         * \brief コードのレベル（詳細度）が、PLATEAUの仕様上考えられる中でもっとも大きいものであるときにtrueを返します。
+        */
+        bool isLargestLevel() const override;
+        bool isSmallerThanNormalGml() const override;
+        bool isNormalGmlLevel() const override;
 
         bool operator==(const MeshCode& other) const;
 
-        //! setに入れるために演算子オーバーロードします。
-        bool operator<(MeshCode& other) const;
-        bool operator<(const MeshCode& other) const;
+
 
     private:
-        int first_row_;
-        int first_col_;
-        int second_row_;
-        int second_col_;
-        int third_row_;
-        int third_col_;
-        int fourth_row_;
-        int fourth_col_;
-        int fifth_row_;
-        int fifth_col_;
-        int level_;
-        bool is_valid_;
+        int first_row_ = 0;
+        int first_col_ = 0;
+        int second_row_ = 0;
+        int second_col_ = 0;
+        int third_row_ = 0;
+        int third_col_ = 0;
+        int fourth_row_ = 0;
+        int fourth_col_ = 0;
+        int fifth_row_ = 0;
+        int fifth_col_ = 0;
+        int level_ = 0;
+        bool is_valid_ = false;
 
         static void nextRow(MeshCode& mesh_code);
         static void nextCol(MeshCode& mesh_code);

--- a/Source/ThirdParty/include/plateau/dataset/standard_map_grid.h
+++ b/Source/ThirdParty/include/plateau/dataset/standard_map_grid.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <string>
+
+#include <libplateau_api.h>
+#include "plateau/geometry/geo_coordinate.h"
+#include "plateau/dataset/grid_code.h"
+
+namespace plateau::dataset {
+    /**
+     * \brief 国土基本図図郭を表します。
+     * 
+     * 国土基本図の図郭コードを扱い、緯度経度範囲の取得などの機能を提供します。
+     */
+    class LIBPLATEAU_EXPORT StandardMapGrid : public GridCode {
+    public:
+        explicit StandardMapGrid(std::string  code);
+        StandardMapGrid() = default;
+
+        /**
+         * \brief 図郭コードを文字列として取得します。
+         */
+        std::string get() const override;
+
+        /**
+         * \brief 図郭の緯度経度範囲を取得します。
+         */
+        geometry::Extent getExtent() const override;
+
+        /**
+         * \brief 図郭コードが適切な値かどうかを返します。
+         */
+        bool isValid() const override;
+
+        /**
+         * \brief １段階上のレベルのグリッドコードに変換します。
+         */
+        std::shared_ptr<GridCode> upper() const override;
+        GridCode* upperRaw() const override;
+
+        /**
+         * \brief コードのレベル（詳細度）を取得します。
+         */
+        int getLevel() const override;
+
+        /**
+         * \brief コードのレベル（詳細度）が、PLATEAUの仕様上考えられる中でもっとも大きいものであるときにtrueを返します。
+         */
+        bool isLargestLevel() const override;
+        bool isSmallerThanNormalGml() const override;
+        bool isNormalGmlLevel() const override;
+
+        bool operator==(const StandardMapGrid& other) const;
+        bool operator<(const StandardMapGrid& other) const;
+
+    private:
+        std::string code_;  // 図郭コード
+        bool is_valid_ = false;     // コードが有効かどうか
+    };
+} 

--- a/Source/ThirdParty/include/plateau/geometry/geo_coordinate.h
+++ b/Source/ThirdParty/include/plateau/geometry/geo_coordinate.h
@@ -16,8 +16,7 @@ namespace plateau::geometry {
      * EPSGコードが 6697 のとき、それは
      * 「日本測地系2011における経緯度座標系と東京湾平均海面を基準とする標高の複合座標参照系」
      * になります。
-     * TODO
-     * EPSGコードの判別と、それによって処理を変える機能は未実装です。
+     * EPSGコードが 10162 ～ 10174　の場合は平面直角座標系となります。
      */
     struct GeoCoordinate {
         double latitude;
@@ -95,8 +94,8 @@ namespace plateau::geometry {
 
         static Extent all() {
             return {
-                    GeoCoordinate(-90, -180, -9999),
-                    GeoCoordinate(90, 180, 9999)
+                    GeoCoordinate(-9999999, -9999999, -9999),
+                    GeoCoordinate(9999999, 9999999, 9999)
             };
         }
     };

--- a/Source/ThirdParty/include/plateau/geometry/geo_reference.h
+++ b/Source/ThirdParty/include/plateau/geometry/geo_reference.h
@@ -20,14 +20,15 @@ namespace plateau::geometry {
         /**
          * 緯度・経度・高さで表現される座標を平面直角座標系に変換します。
          * 座標軸変換を含みます。
-         */
+         */    
         TVec3d project(const GeoCoordinate& point) const;
         TVec3d project(const TVec3d& lat_lon) const;
         /// project の座標軸変換をしない版です。座標軸は ENU → ENU であるとします。 reference_point_ は ENUに変換されます。
         TVec3d projectWithoutAxisConvert(const TVec3d& lat_lon) const;
         TVec3d convertAxisToENU(const TVec3d& vertex) const;
+        TVec3d convert(const TVec3d& lat_lon, const bool convert_axis = true, const bool project = true) const;
         static TVec3d convertAxisFromENUTo(CoordinateSystem axis, const TVec3d& vertex);
-        static TVec3d convertAxisToENU(CoordinateSystem axis, const TVec3d& vertex);
+        static TVec3d convertAxisToENU(CoordinateSystem axis, const TVec3d& vertex); 
 
         GeoCoordinate unproject(const TVec3d& point) const;
 

--- a/Source/ThirdParty/include/plateau/network/client.h
+++ b/Source/ThirdParty/include/plateau/network/client.h
@@ -1,7 +1,10 @@
 #pragma once
 #include <string>
 #include <vector>
-#include <plateau/dataset/mesh_code.h>
+#include <map>
+#include <memory>
+#include <plateau/dataset/grid_code.h>
+#include "libplateau_api.h"
 
 namespace plateau::network {
 
@@ -19,7 +22,7 @@ namespace plateau::network {
      * データセットに含まれるファイルです。
      */
     struct DatasetFileItem {
-        std::string mesh_code;
+        std::string grid_code;
         std::string url;
         int max_lod = 0;
     };

--- a/Source/ThirdParty/lib/windows/plateau_combined.lib
+++ b/Source/ThirdParty/lib/windows/plateau_combined.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65835f4035d2c17b024e667ad08e9ff17ca435cf7a098737fb6dc8bcdc7fd409
-size 296889748
+oid sha256:c32ed0553a437ddc4f1e0dde1fa2ca7a35d147a2d09b9dab11095cfd69b618a8
+size 294248598

--- a/Source/ThirdParty/lib/windows/plateau_combined.lib
+++ b/Source/ThirdParty/lib/windows/plateau_combined.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eca9f6e4dea6073635585acae83dd70534faacf4de1d84d305ccc9365aa1e3dc
+oid sha256:9bd921af53d54cdcc4627c1e1aca6afcd2fedc4559648d89fe17d01fd216c784
 size 294644606

--- a/Source/ThirdParty/lib/windows/plateau_combined.lib
+++ b/Source/ThirdParty/lib/windows/plateau_combined.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c32ed0553a437ddc4f1e0dde1fa2ca7a35d147a2d09b9dab11095cfd69b618a8
-size 294248598
+oid sha256:eca9f6e4dea6073635585acae83dd70534faacf4de1d84d305ccc9365aa1e3dc
+size 294644606


### PR DESCRIPTION

## 実装内容
C++のMeshCodeからGridCodeに移行しました。


## マージ前確認項目
- [ ] Squash and Mergeが選択されていること
- [ ] UI、挙動に変更ある場合、ユーザーマニュアルが更新されていること
- [ ] [ユニットテスト](/Documentation/developer-guide/UnitTest.md)が通っていること

## 動作確認
今まで通りローカルインポート、サーバーインポートで範囲選択してインポートできればOKです。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 「グリッドコード」対応の追加により、従来の「メッシュコード」から「グリッドコード」への移行が行われました。

- **機能改善**
  - エディタ、インポート機能、API、UIパネルなど全体で「メッシュコード」表記が「グリッドコード」に統一されました。
  - コード入力、選択、フィルタリング、情報表示、エリア選択などの操作が「グリッドコード」ベースに刷新されました。
  - 地理座標変換機能に新たなメソッドが追加されました。

- **互換性**
  - プロパティ名変更に伴う過去バージョンとの互換性を保つリダイレクト設定が追加されました。

- **ドキュメント**
  - UIやAPIの引数名・説明が「グリッドコード」に更新されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->